### PR TITLE
🐛 Fix misleading sign-up message

### DIFF
--- a/client/src/common/components/LoginDialog/LoginDialog.jsx
+++ b/client/src/common/components/LoginDialog/LoginDialog.jsx
@@ -22,21 +22,25 @@ export const LoginDialog = ({ open }) => {
     const { updateSessionToken, firstTimeSetup } = useContext(UserContext);
 
     const createAccountFirst = async () => {
-        let resultObj;
         try {
-            resultObj = await request("accounts/register", "POST", { username, password, firstName, lastName });
+            await request("accounts/register", "POST", { username, password, firstName, lastName });
 
-            if (resultObj.code) throw new Error(resultObj.message);
+            return true;
         } catch (error) {
+            if (error.message.toString().includes("^(?=.*[0-9])")) {
+                setError("Password must contain at least one number and one special character");
+                return false;
+            }
+
             setError(error.message || "An error occurred");
-            return;
+            return false;
         }
     }
 
     const submit = async (event) => {
         event.preventDefault();
 
-        if (firstTimeSetup) await createAccountFirst();
+        if (firstTimeSetup && !await createAccountFirst()) return;
 
         let resultObj;
         try {
@@ -60,7 +64,7 @@ export const LoginDialog = ({ open }) => {
 
     useEffect(() => {
         setError("");
-    }, [username, password, code]);
+    }, [username, firstName, lastName, password, code]);
 
     return (
         <DialogProvider disableClosing open={open}>


### PR DESCRIPTION
## 📋 Description

As explained in #23 and #2, the sign-up dialog contains misleading error messages. This PR adds proper error messages.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #2 and #23
