### PR TITLE
🐛 Fix protocol error in 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apk add --no-cache \
 
 RUN git clone --depth=1 https://github.com/apache/guacamole-server.git \
     && cd guacamole-server \
+    && git fetch --all --tags \
+    && git checkout 1.5.5 \
     && autoreconf -fi \
     && ./configure --with-init-dir=/etc/init.d --enable-rdp \
     && make \


### PR DESCRIPTION
## 🐛 Fix protocol error in 1.6.0

This PR updates the `guacd` version to `1.5.5`, which resolves the issue with the Proxmox VMs not connecting.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #77 
Fixes #76 