### PR TITLE
🔀 Migrate legacy sass -> sass-embedded

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,6 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "react-use-websocket": "^4.9.0",
-    "sass": "^1.80.3",
     "simple-icons": "^13.14.1",
     "ua-parser-js": "^1.0.39",
     "xterm": "^5.3.0",
@@ -36,6 +35,7 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.13",
     "globals": "^15.11.0",
+    "sass-embedded": "^1.80.3",
     "vite": "^5.4.9"
   }
 }

--- a/client/src/common/components/Button/styles.sass
+++ b/client/src/common/components/Button/styles.sass
@@ -1,13 +1,13 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .btn
   display: flex
   align-items: center
   justify-content: center
   gap: 0.5rem
-  background-color: $primary-opacity
-  border: 1px solid $gray
-  color: $white
+  background-color: colors.$primary-opacity
+  border: 1px solid colors.$gray
+  color: colors.$white
   border-radius: 0.5rem
   padding: 0.8rem 1rem
   cursor: pointer
@@ -21,7 +21,7 @@
     margin: 0
     font-size: 1rem
     font-weight: 500
-    color: $white
+    color: colors.$white
 
   &:hover
     filter: brightness(0.8)
@@ -30,8 +30,8 @@
     transform: scale(0.97)
 
   &:disabled
-    background-color: $gray
+    background-color: colors.$gray
     cursor: not-allowed
 
 .type-secondary
-  background-color: $gray
+  background-color: colors.$gray

--- a/client/src/common/components/Dialog/styles.sass
+++ b/client/src/common/components/Dialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .dialog-area
   position: fixed
@@ -23,9 +23,9 @@
 
 .dialog
   padding: 15px
-  background-color: $darker-gray
-  border: 1px solid $dark-gray
-  color: $white
+  background-color: colors.$darker-gray
+  border: 1px solid colors.$dark-gray
+  color: colors.$white
   backdrop-filter: blur(1rem)
   border-radius: 15px
   transition: all 0.2s

--- a/client/src/common/components/IconInput/styles.sass
+++ b/client/src/common/components/IconInput/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .input-container
   position: relative
@@ -11,13 +11,13 @@
   width: 2rem
   height: 2rem
   transform: translateY(-50%)
-  color: $light-gray
+  color: colors.$light-gray
 
 .input
   padding: 0.8rem 2rem 0.8rem 3.5rem
-  border: 1px solid $gray
-  background-color: $dark-gray
-  color: $light-gray
+  border: 1px solid colors.$gray
+  background-color: colors.$dark-gray
+  color: colors.$light-gray
   box-sizing: border-box
   border-radius: 0.7rem
   font-size: 14pt
@@ -25,5 +25,5 @@
   outline: none
 
   &:focus
-    border: 1px solid $primary
-    background-color: $gray
+    border: 1px solid colors.$primary
+    background-color: colors.$gray

--- a/client/src/common/components/LoginDialog/styles.sass
+++ b/client/src/common/components/LoginDialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .login-dialog
   display: flex
@@ -15,9 +15,9 @@
     justify-content: center
     width: 18rem
     padding: 0.5rem 1rem
-    background-color: $error-opacity
-    border: 1px solid $error
-    color: $error
+    background-color: colors.$error-opacity
+    border: 1px solid colors.$gray
+    color: colors.$error
     border-radius: 0.5rem
     font-size: 0.9rem
     margin: 0
@@ -53,5 +53,5 @@
     gap: 0.3rem
 
     label
-      color: $subtext
+      color: colors.$subtext
       font-weight: 600

--- a/client/src/common/components/SelectBox/styles.sass
+++ b/client/src/common/components/SelectBox/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .select-box
   position: relative
@@ -8,9 +8,9 @@
 
   &__selected
     padding: 0.8rem
-    border: 1px solid $gray
-    background-color: $dark-gray
-    color: $light-gray
+    border: 1px solid colors.$gray
+    background-color: colors.$dark-gray
+    color: colors.$light-gray
     box-sizing: border-box
     border-radius: 0.7rem
     font-size: 14pt
@@ -37,8 +37,8 @@
     top: calc(100% + 5px)
     left: 0
     width: 100%
-    border: 1px solid $gray
-    background-color: $gray-full
+    border: 1px solid colors.$gray
+    background-color: colors.$gray-full
     backdrop-filter: blur(1rem)
     border-radius: 0.7rem
     z-index: 1000
@@ -54,4 +54,4 @@
       border-bottom: none
 
     &:hover, &.selected
-      background-color: $gray
+      background-color: colors.$gray

--- a/client/src/common/components/Sidebar/styles.sass
+++ b/client/src/common/components/Sidebar/styles.sass
@@ -1,15 +1,15 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .sidebar
   width: 5rem
   user-select: none
-  background-color: $lighter-background
+  background-color: colors.$lighter-background
   height: 100%
   display: flex
   flex-direction: column
   justify-content: space-between
   align-items: center
-  border-right: 2px solid $dark-gray
+  border-right: 2px solid colors.$dark-gray
   overflow: hidden
 
   .sidebar-top
@@ -23,7 +23,7 @@
     height: 3.5rem
 
   hr
-    background-color: $dark-gray
+    background-color: colors.$dark-gray
     width: 50%
     margin: 1rem 0
     border: none
@@ -41,7 +41,7 @@
       display: flex
       justify-content: center
       align-items: center
-      color: $white
+      color: colors.$white
       border: 1px solid transparent
       border-radius: 1rem
       transition: all 0.2s
@@ -51,16 +51,16 @@
         height: 2.5rem
 
       &:hover
-        color: $primary
+        color: colors.$primary
 
     .nav-item-active
-      background-color: $dark-gray
-      border: 1px solid $gray
-      color: $primary
+      background-color: colors.$dark-gray
+      border: 1px solid colors.$gray
+      color: colors.$primary
 
 
   .log-out-btn
-    border-top: 2px solid $dark-gray
+    border-top: 2px solid colors.$dark-gray
     width: 100%
     height: 3rem
     display: flex
@@ -74,4 +74,4 @@
       height: 2rem
 
     &:hover
-      color: $error
+      color: colors.$error

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -1,10 +1,10 @@
-@import "colors"
+@use "colors"
 
 body, html
   margin: 0
   overflow-x: hidden
-  background-color: $background
-  color: $white
+  background-color: colors.$background
+  color: colors.$white
   font-family: "Plus Jakarta Sans", sans-serif
   font-weight: 700
 
@@ -17,7 +17,7 @@ body, html
   width: 13px
 
 ::-webkit-scrollbar-thumb
-  background: $lighter-background
+  background: colors.$lighter-background
   border-radius: 10px
 
 ::-webkit-scrollbar-thumb:hover

--- a/client/src/pages/Apps/components/AppInstaller/components/InstallStep/styles.sass
+++ b/client/src/pages/Apps/components/AppInstaller/components/InstallStep/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .install-step
   display: flex
@@ -15,13 +15,13 @@
     border-radius: 40%
 
   .progress-indicator
-    background-color: $primary-opacity
+    background-color: colors.$primary-opacity
     svg
       width: 30px
       height: 30px
 
     .progress-circle
-      stroke: $primary
+      stroke: colors.$primary
       stroke-width: 3
       stroke-linecap: round
       transform: rotate(-90deg)
@@ -29,26 +29,26 @@
       transition: stroke-dashoffset 0.35s ease
 
   .skip-indicator
-    background-color: $gray
-    color: $light-gray
+    background-color: colors.$gray
+    color: colors.$light-gray
 
   .image-indicator img
     height: 1.4rem
 
   .soon-indicator
-    outline: 2px solid $gray
+    outline: 2px solid colors.$gray
 
   .success-indicator
-    background-color: $success-opacity
-    color: $success
+    background-color: colors.$success-opacity
+    color: colors.$success
 
   .error-indicator
-    background-color: $error-opacity
-    color: $error
+    background-color: colors.$error-opacity
+    color: colors.$error
 
   .loading-indicator
-    background-color: $primary-opacity
-    color: $primary
+    background-color: colors.$primary-opacity
+    color: colors.$primary
 
   h2
     font-size: 1.3rem

--- a/client/src/pages/Apps/components/AppInstaller/components/LogDialog/styles.sass
+++ b/client/src/pages/Apps/components/AppInstaller/components/LogDialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .log-dialog
   display: flex

--- a/client/src/pages/Apps/components/AppInstaller/styles.sass
+++ b/client/src/pages/Apps/components/AppInstaller/styles.sass
@@ -1,10 +1,10 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .app-installer
   display: flex
   flex-direction: column
-  background-color: $dark-gray
-  border: 1px solid $gray
+  background-color: colors.$dark-gray
+  border: 1px solid colors.$gray
   padding: 1rem 1.3rem
   border-radius: 1rem
   gap: 2rem
@@ -32,8 +32,8 @@
     gap: 1rem
 
     .app-img
-      background-color: $dark-gray
-      border: 1px solid $gray
+      background-color: colors.$dark-gray
+      border: 1px solid colors.$gray
       border-radius: 1rem
       display: flex
       padding: 0.5rem
@@ -51,4 +51,4 @@
     p
       margin: 0
       font-weight: 600
-      color: $subtext
+      color: colors.$subtext

--- a/client/src/pages/Apps/components/AppItem/styles.sass
+++ b/client/src/pages/Apps/components/AppItem/styles.sass
@@ -1,10 +1,10 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .app-item
   display: flex
   flex-direction: column
-  background-color: $dark-gray
-  border: 1px solid $gray
+  background-color: colors.$dark-gray
+  border: 1px solid colors.$gray
   padding: 1rem 1.3rem
   border-radius: 1rem
   width: 15rem
@@ -20,8 +20,8 @@
     gap: 1rem
 
     .app-img
-      background-color: $dark-gray
-      border: 1px solid $gray
+      background-color: colors.$dark-gray
+      border: 1px solid colors.$gray
       border-radius: 1rem
       padding: 0.5rem
       display: flex
@@ -39,7 +39,7 @@
     p
       margin: 0
       font-weight: 600
-      color: $subtext
+      color: colors.$subtext
 
   .action-area
     display: flex

--- a/client/src/pages/Apps/components/AppNavigation/styles.sass
+++ b/client/src/pages/Apps/components/AppNavigation/styles.sass
@@ -1,14 +1,14 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .app-navigation
   height: 100%
   padding: 1rem 0.5rem
-  background-color: $lighter-background
+  background-color: colors.$lighter-background
   display: flex
   box-sizing: border-box
   flex-direction: column
   align-items: center
-  border-right: 2px solid $dark-gray
+  border-right: 2px solid colors.$dark-gray
   user-select: none
 
   .settings-item
@@ -30,7 +30,7 @@
       margin: 0
 
     &:hover
-      border: 1px solid $gray
+      border: 1px solid colors.$gray
   .settings-item-active
-    background-color: $dark-gray
-    border: 1px solid $gray
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray

--- a/client/src/pages/Apps/components/SourceDialog/components/SourceItem/styles.sass
+++ b/client/src/pages/Apps/components/SourceDialog/components/SourceItem/styles.sass
@@ -1,12 +1,12 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .source-item
   display: flex
   flex-direction: column
   justify-content: center
   gap: 1rem
-  background-color: $dark-gray
-  border: 1px solid $gray
+  background-color: colors.$dark-gray
+  border: 1px solid colors.$gray
   padding: 1rem
   border-radius: 0.5rem
   width: 22rem
@@ -16,7 +16,7 @@
 
   .action-area .action-delete
     cursor: pointer
-    color: $error
+    color: colors.$error
 
   .source-header
     display: flex
@@ -24,7 +24,7 @@
     align-items: center
 
   .header-official svg
-    color: $primary
+    color: colors.$primary
 
   .source-info
     display: flex
@@ -32,7 +32,7 @@
     align-items: center
 
     span
-      color: $subtext
+      color: colors.$subtext
       font-weight: 600
 
   .edit-area .error
@@ -40,9 +40,9 @@
     align-items: center
     justify-content: center
     padding: 0.5rem 1rem
-    background-color: $error-opacity
-    border: 1px solid $error
-    color: $error
+    background-color: colors.$error-opacity
+    border: 1px solid colors.$gray
+    color: colors.$error
     border-radius: 0.5rem
     font-size: 0.9rem
     margin: 0

--- a/client/src/pages/Apps/components/SourceDialog/styles.sass
+++ b/client/src/pages/Apps/components/SourceDialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .source-dialog
   display: flex

--- a/client/src/pages/Apps/components/StoreHeader/styles.sass
+++ b/client/src/pages/Apps/components/StoreHeader/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .store-header
   display: flex
@@ -23,4 +23,4 @@
     margin: 0
     font-size: 1rem
     font-weight: 600
-    color: $subtext
+    color: colors.$subtext

--- a/client/src/pages/Apps/styles.sass
+++ b/client/src/pages/Apps/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .apps-page
   display: grid

--- a/client/src/pages/Servers/components/ProxmoxDialog/styles.sass
+++ b/client/src/pages/Servers/components/ProxmoxDialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .proxmox-dialog
   display: flex
@@ -14,7 +14,7 @@
     font-size: 0.9rem
 
   .error
-    border: 1px solid $error
+    border: 1px solid colors.$gray
 
   .form-group
     display: flex
@@ -22,7 +22,7 @@
     gap: 0.3rem
 
     label
-      color: $subtext
+      color: colors.$subtext
       font-weight: 600
 
   .ip-row
@@ -31,14 +31,14 @@
 
   .small-input
     padding: 0.8rem
-    border: 1px solid $gray
+    border: 1px solid colors.$gray
     width: 3rem
-    background-color: $dark-gray
-    color: $light-gray
+    background-color: colors.$dark-gray
+    color: colors.$light-gray
     border-radius: 0.5rem
     font-size: 14pt
     outline: none
 
     &:focus
-      border: 1px solid $primary
-      background-color: $gray
+      border: 1px solid colors.$primary
+      background-color: colors.$gray

--- a/client/src/pages/Servers/components/ServerDialog/styles.sass
+++ b/client/src/pages/Servers/components/ServerDialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .server-dialog
   display: flex
@@ -41,22 +41,22 @@
     gap: 0.3rem
 
     label
-      color: $subtext
+      color: colors.$subtext
       font-weight: 600
 
     .small-input
       padding: 0.8rem
       width: 3rem
-      border: 1px solid $gray
-      background-color: $dark-gray
-      color: $light-gray
+      border: 1px solid colors.$gray
+      background-color: colors.$dark-gray
+      color: colors.$light-gray
       border-radius: 0.5rem
       font-size: 14pt
       outline: none
 
       &:focus
-        border: 1px solid $primary
-        background-color: $gray
+        border: 1px solid colors.$primary
+        background-color: colors.$gray
 
   .server-dialog-title
     h2
@@ -79,15 +79,15 @@
       font-weight: 600
 
     &:hover
-      background-color: $darker-gray
+      background-color: colors.$darker-gray
 
   .tabs-item-active
-    background-color: $gray
-    border-bottom: 2px solid $primary
+    background-color: colors.$gray
+    border-bottom: 2px solid colors.$primary
     border-radius: 0.5rem 0.5rem 0 0
 
     &:hover
-      background-color: $gray
+      background-color: colors.$gray
 
   .identities
     display: flex
@@ -96,8 +96,8 @@
 
   .identity
     display: flex
-    background-color: $dark-gray
-    border: 1px solid $gray
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
     padding: 1rem
     border-radius: 0.5rem
     flex-direction: column

--- a/client/src/pages/Servers/components/ServerList/components/ContextMenu/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/components/ContextMenu/styles.sass
@@ -1,16 +1,16 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .context-menu
-  background-color: $darker-gray
+  background-color: colors.$darker-gray
   backdrop-filter: blur(1rem)
-  border: 2px solid $dark-gray
+  border: 2px solid colors.$dark-gray
   border-radius: 0.5rem
   padding: 0.5rem
   position: absolute
   z-index: 1000
 
   .context-item
-    color: $white
+    color: colors.$white
     padding: 0.5rem 1rem
     cursor: pointer
     transition: background-color 0.2s
@@ -33,4 +33,4 @@
       margin: 0
 
     &:hover
-      background-color: $dark-gray
+      background-color: colors.$dark-gray

--- a/client/src/pages/Servers/components/ServerList/components/FolderObject/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/components/FolderObject/styles.sass
@@ -1,9 +1,9 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .folder-object
   display: flex
   gap: 0.5rem
-  color: $light-gray
+  color: colors.$light-gray
   border: 1px solid transparent
   padding: 0.4rem
   font-weight: 600
@@ -16,16 +16,16 @@
     margin: 0
 
   &:hover
-    color: $white
-    background-color: $dark-gray
-    border: 1px solid $gray
+    color: colors.$white
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
     border-radius: 0.3rem
 
   input
     padding: 0.4rem 0.6rem
-    border: 1px solid $gray
+    border: 1px solid colors.$gray
     background-color: transparent
-    color: $light-gray
+    color: colors.$light-gray
     box-sizing: border-box
     border-radius: 0.7rem
     font-size: 12pt

--- a/client/src/pages/Servers/components/ServerList/components/PVEObject/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/components/PVEObject/styles.sass
@@ -1,9 +1,9 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .pve-object
   display: flex
   gap: 0.5rem
-  color: $light-gray
+  color: colors.$light-gray
   border: 1px solid transparent
   padding: 0.4rem
   font-weight: 600
@@ -16,16 +16,16 @@
     margin: 0
 
   &:hover
-    color: $white
-    background-color: $dark-gray
-    border: 1px solid $gray
+    color: colors.$white
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
     border-radius: 0.3rem
 
   input
     padding: 0.4rem 0.6rem
-    border: 1px solid $gray
+    border: 1px solid colors.$gray
     background-color: transparent
-    color: $light-gray
+    color: colors.$light-gray
     box-sizing: border-box
     border-radius: 0.7rem
     font-size: 12pt

--- a/client/src/pages/Servers/components/ServerList/components/ServerObject/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/components/ServerObject/styles.sass
@@ -1,10 +1,10 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .server-object
   display: flex
   align-items: center
   gap: 0.5rem
-  color: $light-gray
+  color: colors.$light-gray
   border: 1px solid transparent
   padding: 0.4rem
   cursor: pointer
@@ -17,22 +17,22 @@
     border-radius: 0.2rem
     justify-content: center
     align-items: center
-    background-color: $primary
+    background-color: colors.$primary
     svg
       width: 1rem
 
   .pve-icon
-    background-color: $warning
+    background-color: colors.$warning
 
   .pve-icon-offline
-    background-color: $gray
+    background-color: colors.$gray
 
   p
     margin: 0
     flex: 1
 
   &:hover
-    color: $white
-    background-color: $dark-gray
-    border: 1px solid $gray
+    color: colors.$white
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
     border-radius: 0.3rem

--- a/client/src/pages/Servers/components/ServerList/components/ServerSearch/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/components/ServerSearch/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .server-search
   position: relative
@@ -11,7 +11,7 @@
   width: 2rem
   height: 2rem
   transform: translateY(-50%)
-  color: $subtext
+  color: colors.$subtext
 
 .info-container
   position: absolute
@@ -20,21 +20,21 @@
   transform: translateY(-50%)
   user-select: none
   cursor: pointer
-  color: $subtext
+  color: colors.$subtext
 
   p
     margin: 0
     padding: 0.2rem 0.5rem
     border-radius: 0.5rem
     font-size: 10pt
-    border: 1px solid $gray
+    border: 1px solid colors.$gray
 
 .search-input
   user-select: none
   padding: 0.8rem 6rem 0.8rem 3.5rem
-  border: 1px solid $gray
-  background-color: $dark-gray
-  color: $light-gray
+  border: 1px solid colors.$gray
+  background-color: colors.$dark-gray
+  color: colors.$light-gray
   box-sizing: border-box
   border-radius: 0.7rem
   font-size: 14pt
@@ -42,5 +42,5 @@
   outline: none
 
   &:focus
-    border: 1px solid $primary
-    background-color: $gray
+    border: 1px solid colors.$primary
+    background-color: colors.$gray

--- a/client/src/pages/Servers/components/ServerList/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/styles.sass
@@ -1,13 +1,13 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .server-list
   width: 18rem
-  background-color: $lighter-background
+  background-color: colors.$lighter-background
   height: 100%
   display: flex
   flex-direction: column
   align-items: center
-  border-right: 2px solid $dark-gray
+  border-right: 2px solid colors.$dark-gray
 
   .server-list-inner
     margin-top: 1rem
@@ -31,7 +31,7 @@
       flex-direction: column
       justify-content: center
       align-items: center
-      color: $subtext
+      color: colors.$subtext
 
       svg
         width: 5rem

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .server-tabs
   display: flex
@@ -29,8 +29,8 @@
       white-space: nowrap
 
       &:hover
-        background-color: $gray
-        border-bottom: 2px solid $primary-opacity
+        background-color: colors.$gray
+        border-bottom: 2px solid colors.$primary-opacity
 
       svg
         width: 1.5rem
@@ -41,9 +41,9 @@
         font-size: 1.3rem
 
     .server-tab-active
-      background-color: $gray
-      border-bottom: 2px solid $primary
+      background-color: colors.$gray
+      border-bottom: 2px solid colors.$primary
 
       &:hover
-        background-color: $gray
-        border-bottom: 2px solid $primary
+        background-color: colors.$gray
+        border-bottom: 2px solid colors.$primary

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/ActionBar/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/ActionBar/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .action-bar
   display: flex
@@ -13,20 +13,20 @@
     transition: color 0.2s
 
     &:hover
-      color: $primary
+      color: colors.$primary
 
   .nav-disabled
-    color: $gray
+    color: colors.$gray
     cursor: not-allowed
 
     &:hover
-      color: $gray
+      color: colors.$gray
 
   .address-bar
     user-select: none
     padding: 0.5rem 1rem
-    background-color: $dark-gray
-    border: 1px solid $gray
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
     border-radius: 0.5rem
     display: flex
     gap: 0.5rem
@@ -34,7 +34,7 @@
     margin: 0 1rem
 
     .path-part-divider
-      color: $subtext
+      color: colors.$subtext
       cursor: pointer
 
     .path-part

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/FileEditor/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/FileEditor/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .file-editor
   margin: 0 2rem
@@ -43,7 +43,7 @@
       transition: color 0.2s
 
       &:hover
-        color: $primary
+        color: colors.$primary
 
     .icon-disabled
       display: none

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/FileList/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/FileList/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .file-list
   display: flex
@@ -16,7 +16,7 @@
     grid-template-columns: 1fr 1fr 1fr
     align-items: center
     padding: 0.5rem 1rem
-    background-color: $dark-gray
+    background-color: colors.$dark-gray
     cursor: pointer
 
     .file-name

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .file-renderer
   height: 100%
@@ -13,14 +13,14 @@
     align-items: center
     background-color: rgba(0, 0, 0, 0.5)
     backdrop-filter: blur(0.3rem)
-    color: $white
+    color: colors.$white
     font-size: 1.5rem
     z-index: 1
 
     .drag-item
       padding: 4rem 2rem
       width: 20rem
-      border: 0.2rem dashed $white
+      border: 0.2rem dashed colors.$white
       border-radius: 0.5rem
       display: flex
       flex-direction: column
@@ -45,4 +45,4 @@
     height: 0.5rem
     border-top-left-radius: 0.1rem
     border-top-right-radius: 0.1rem
-    background-color: $primary
+    background-color: colors.$primary

--- a/client/src/pages/Servers/components/ViewContainer/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .view-container
   display: flex
@@ -8,7 +8,7 @@
 
 .view
   display: none
-  background-color: $terminal
+  background-color: colors.$terminal
   height: 100%
 
 .view-layouter

--- a/client/src/pages/Servers/styles.sass
+++ b/client/src/pages/Servers/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .server-page
   display: grid
@@ -22,14 +22,14 @@
       gap: 1rem
 
     span
-      color: $primary
+      color: colors.$primary
 
     h1
       margin: 0
 
     p
       margin: 0.7rem 0 1.5rem 0
-      color: $subtext
+      color: colors.$subtext
       font-size: 16pt
       font-weight: 600
 

--- a/client/src/pages/Settings/components/SettingsNavigation/components/SettingsItem/styles.sass
+++ b/client/src/pages/Settings/components/SettingsNavigation/components/SettingsItem/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .settings-item
   box-sizing: border-box
@@ -19,7 +19,7 @@
     margin: 0
 
   &:hover
-    border: 1px solid $gray
+    border: 1px solid colors.$gray
 .settings-item-active
-  background-color: $dark-gray
-  border: 1px solid $gray
+  background-color: colors.$dark-gray
+  border: 1px solid colors.$gray

--- a/client/src/pages/Settings/components/SettingsNavigation/styles.sass
+++ b/client/src/pages/Settings/components/SettingsNavigation/styles.sass
@@ -1,11 +1,11 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .settings-navigation
-  background-color: $lighter-background
+  background-color: colors.$lighter-background
   height: 100%
   display: flex
   flex-direction: column
-  border-right: 2px solid $dark-gray
+  border-right: 2px solid colors.$dark-gray
   user-select: none
 
   p
@@ -13,7 +13,7 @@
     padding: 0.5rem 1rem
     font-size: 1rem
     font-weight: 600
-    color: $subtext
+    color: colors.$subtext
 
   .settings-group
     display: flex

--- a/client/src/pages/Settings/pages/Account/dialogs/PasswordChange/styles.sass
+++ b/client/src/pages/Settings/pages/Account/dialogs/PasswordChange/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .password-change
   display: flex
@@ -14,4 +14,4 @@
     font-size: 0.9rem
 
   .error
-    border: 1px solid $error
+    border: 1px solid colors.$gray

--- a/client/src/pages/Settings/pages/Account/dialogs/TwoFactorAuthentication/styles.sass
+++ b/client/src/pages/Settings/pages/Account/dialogs/TwoFactorAuthentication/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .two-factor-dialog
   display: flex
@@ -20,11 +20,11 @@
 
     .totp-code
       user-select: text
-      color: $primary
+      color: colors.$primary
 
 
   .setup-error
-    border: 1px solid $error
+    border: 1px solid colors.$gray
 
   .action-row
     display: flex

--- a/client/src/pages/Settings/pages/Account/styles.sass
+++ b/client/src/pages/Settings/pages/Account/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .account-page
   display: flex
@@ -11,7 +11,7 @@
     margin: 0
 
   p
-    color: $subtext
+    color: colors.$subtext
 
   .tfa-title
     display: flex
@@ -24,12 +24,12 @@
       border-radius: 0.5rem
 
     .active
-      background-color: $success-opacity
-      color: $success
+      background-color: colors.$success-opacity
+      color: colors.$success
 
     .inactive
-      background-color: $error-opacity
-      color: $error
+      background-color: colors.$error-opacity
+      color: colors.$error
 
   .section-inner
     margin-top: 1rem
@@ -45,8 +45,8 @@
       gap: 0.3rem
 
       label
-        color: $subtext
+        color: colors.$subtext
         font-weight: 600
 
       .fd-updated
-        border: 1px solid $success
+        border: 1px solid colors.$success

--- a/client/src/pages/Settings/pages/Sessions/styles.sass
+++ b/client/src/pages/Settings/pages/Sessions/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .sessions-page
   display: flex
@@ -8,7 +8,7 @@
 
 
   .session
-    border: 2px solid $gray
+    border: 2px solid colors.$gray
     padding: 1rem 1.5rem
     border-radius: 1rem
     display: flex
@@ -30,15 +30,15 @@
 
       p
         font-weight: 600
-        color: $subtext
+        color: colors.$subtext
 
     .icon-container
       display: flex
       align-items: center
       justify-content: center
       padding: 0.7rem
-      color: $primary
-      background-color: $primary-opacity
+      color: colors.$primary
+      background-color: colors.$primary-opacity
       border-radius: 1rem
 
       svg
@@ -46,5 +46,5 @@
         height: 2rem
 
     .icon-current
-      color: $success
-      background-color: $success-opacity
+      color: colors.$success
+      background-color: colors.$success-opacity

--- a/client/src/pages/Settings/pages/Users/components/CreateUserDialog/styles.sass
+++ b/client/src/pages/Settings/pages/Users/components/CreateUserDialog/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .user-creation-dialog
   display: flex
@@ -10,9 +10,9 @@
     justify-content: center
     align-items: center
     padding: 0.8rem 1rem
-    background-color: $error-opacity
-    border: 1px solid $error
-    color: $error
+    background-color: colors.$error-opacity
+    border: 1px solid colors.$gray
+    color: colors.$error
     border-radius: 0.5rem
     font-size: 0.9rem
     margin: 0
@@ -34,7 +34,7 @@
     gap: 0.3rem
 
     label
-      color: $subtext
+      color: colors.$subtext
       font-weight: 600
 
   .btn-area

--- a/client/src/pages/Settings/pages/Users/styles.sass
+++ b/client/src/pages/Settings/pages/Users/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .users-page
   display: flex
@@ -14,8 +14,8 @@
     display: grid
     grid-template-columns: 2fr 1fr 1fr 1fr
     align-items: center
-    background-color: $dark-gray
-    border: 1px solid $gray
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
     padding: 0.8rem 1rem
     border-radius: 1rem
     position: relative
@@ -32,14 +32,14 @@
       display: flex
       align-items: center
       gap: 0.5rem
-      color: $error
+      color: colors.$error
 
       svg
         width: 2rem
         height: 2rem
 
     .totp-enabled
-      color: $success
+      color: colors.$success
 
     .menu
       width: 2.5rem

--- a/client/src/pages/Settings/styles.sass
+++ b/client/src/pages/Settings/styles.sass
@@ -1,4 +1,4 @@
-@import "@/common/styles/colors"
+@use "@/common/styles/colors"
 
 .settings-page
   display: grid
@@ -9,7 +9,7 @@
     padding: 1rem 2rem
 
     hr
-      background-color: $gray
+      background-color: colors.$gray
       width: 100%
       height: 3px
       border: none

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,6 +4,13 @@ import * as path from "path";
 
 export default defineConfig({
     plugins: [react()],
+    css: {
+        preprocessorOptions: {
+            sass: {
+                api: "modern"
+            }
+        }
+    },
     resolve: {
         alias: {
             "@": path.resolve(__dirname, "src"),

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -188,6 +188,11 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
+"@bufbuild/protobuf@^2.0.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@bufbuild/protobuf/-/protobuf-2.2.0.tgz#3c63dcbb6ef4f6a9f587e3d412c08f9a8f5bcd00"
+  integrity sha512-+imAQkHf7U/Rwvu0wk1XWgsP3WnpCWmK7B48f0XqSNzgk64+grljTKC7pnO/xBiEMUziF7vKRfbBnOQhg126qQ==
+
 "@codemirror/autocomplete@^6.0.0":
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.18.1.tgz#3bd8d62c9c9a14d0706ab0a8adac139eaf1a41f1"
@@ -525,89 +530,6 @@
   integrity sha512-4qZeDcluDFGFTWkHs86VOlHkm6gnKaMql13/gpIcUQ8kzxHgpj31NuCkD8abECVfbULJ3shc7Yt4HJ6Wu6SN4w==
   dependencies:
     prop-types "^15.7.2"
-
-"@parcel/watcher-android-arm64@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz#c2c19a3c442313ff007d2d7a9c2c1dd3e1c9ca84"
-  integrity sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==
-
-"@parcel/watcher-darwin-arm64@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz#c817c7a3b4f3a79c1535bfe54a1c2818d9ffdc34"
-  integrity sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==
-
-"@parcel/watcher-darwin-x64@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz#1a3f69d9323eae4f1c61a5f480a59c478d2cb020"
-  integrity sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==
-
-"@parcel/watcher-freebsd-x64@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz#0d67fef1609f90ba6a8a662bc76a55fc93706fc8"
-  integrity sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==
-
-"@parcel/watcher-linux-arm-glibc@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz#ce5b340da5829b8e546bd00f752ae5292e1c702d"
-  integrity sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==
-
-"@parcel/watcher-linux-arm64-glibc@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz#6d7c00dde6d40608f9554e73998db11b2b1ff7c7"
-  integrity sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==
-
-"@parcel/watcher-linux-arm64-musl@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz#bd39bc71015f08a4a31a47cd89c236b9d6a7f635"
-  integrity sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==
-
-"@parcel/watcher-linux-x64-glibc@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz#0ce29966b082fb6cdd3de44f2f74057eef2c9e39"
-  integrity sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==
-
-"@parcel/watcher-linux-x64-musl@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz#d2ebbf60e407170bb647cd6e447f4f2bab19ad16"
-  integrity sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==
-
-"@parcel/watcher-win32-arm64@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz#eb4deef37e80f0b5e2f215dd6d7a6d40a85f8adc"
-  integrity sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==
-
-"@parcel/watcher-win32-ia32@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz#94fbd4b497be39fd5c8c71ba05436927842c9df7"
-  integrity sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==
-
-"@parcel/watcher-win32-x64@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz#4bf920912f67cae5f2d264f58df81abfea68dadf"
-  integrity sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==
-
-"@parcel/watcher@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.4.1.tgz#a50275151a1bb110879c6123589dba90c19f1bf8"
-  integrity sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==
-  dependencies:
-    detect-libc "^1.0.3"
-    is-glob "^4.0.3"
-    micromatch "^4.0.5"
-    node-addon-api "^7.0.0"
-  optionalDependencies:
-    "@parcel/watcher-android-arm64" "2.4.1"
-    "@parcel/watcher-darwin-arm64" "2.4.1"
-    "@parcel/watcher-darwin-x64" "2.4.1"
-    "@parcel/watcher-freebsd-x64" "2.4.1"
-    "@parcel/watcher-linux-arm-glibc" "2.4.1"
-    "@parcel/watcher-linux-arm64-glibc" "2.4.1"
-    "@parcel/watcher-linux-arm64-musl" "2.4.1"
-    "@parcel/watcher-linux-x64-glibc" "2.4.1"
-    "@parcel/watcher-linux-x64-musl" "2.4.1"
-    "@parcel/watcher-win32-arm64" "2.4.1"
-    "@parcel/watcher-win32-ia32" "2.4.1"
-    "@parcel/watcher-win32-x64" "2.4.1"
 
 "@remix-run/router@1.20.0":
   version "1.20.0"
@@ -950,13 +872,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
-  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
-  dependencies:
-    fill-range "^7.1.1"
-
 browserslist@^4.23.1:
   version "4.23.3"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz"
@@ -966,6 +881,11 @@ browserslist@^4.23.1:
     electron-to-chromium "^1.5.4"
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.0"
+
+buffer-builder@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-builder/-/buffer-builder-0.2.0.tgz#3322cd307d8296dab1f604618593b261a3fade8f"
+  integrity sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==
 
 call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
   version "1.0.7"
@@ -1005,13 +925,6 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.0.tgz#4d603963e5dd762dc5c7bb1cb5664e53a3002225"
-  integrity sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==
-  dependencies:
-    readdirp "^4.0.1"
-
 codemirror@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"
@@ -1048,6 +961,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorjs.io@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/colorjs.io/-/colorjs.io-0.5.2.tgz#63b20139b007591ebc3359932bef84628eb3fcef"
+  integrity sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1134,11 +1052,6 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
-
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -1460,13 +1373,6 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-fill-range@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
-  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
-  dependencies:
-    to-regex-range "^5.0.1"
-
 find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
@@ -1764,11 +1670,6 @@ is-number-object@^1.0.4:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
-  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz"
@@ -1939,14 +1840,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-micromatch@^4.0.5:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
-  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
-
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -1968,11 +1861,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-node-addon-api@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
-  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-releases@^2.0.18:
   version "2.0.18"
@@ -2085,11 +1973,6 @@ picocolors@^1.0.0, picocolors@^1.0.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz"
@@ -2173,11 +2056,6 @@ react@^18.3.1:
   dependencies:
     loose-envify "^1.1.0"
 
-readdirp@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.1.tgz#b2fe35f8dca63183cd3b86883ecc8f720ea96ae6"
-  integrity sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==
-
 reflect.getprototypeof@^1.0.4:
   version "1.0.6"
   resolved "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz"
@@ -2245,6 +2123,13 @@ rollup@^4.20.0:
     "@rollup/rollup-win32-x64-msvc" "4.21.1"
     fsevents "~2.3.2"
 
+rxjs@^7.4.0:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-array-concat@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz"
@@ -2264,15 +2149,139 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
-sass@^1.80.3:
+sass-embedded-android-arm64@1.80.3:
   version "1.80.3"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.80.3.tgz#3f63dd527647d2b3de35f36acb971bda80517423"
-  integrity sha512-ptDWyVmDMVielpz/oWy3YP3nfs7LpJTHIJZboMVs8GEC9eUmtZTZhMHlTW98wY4aEorDfjN38+Wr/XjskFWcfA==
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.80.3.tgz#ac7bac3424eb9f39cf06f14c272a3c4d8b65a2bf"
+  integrity sha512-uaEKdi+PaFc1V87vj2eCUB8B2ThNvEYYu9Qs5sCtx1atEQDtvp/smHYlXOVrg2M4+g2YASkDBQewyk+auZtG0g==
+
+sass-embedded-android-arm@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-arm/-/sass-embedded-android-arm-1.80.3.tgz#7d43385e21af0200bf5512fb3095c1f6c4cacd81"
+  integrity sha512-i87crav7sfShzY7AyUneXvs4SWdJ93QlYIpo/2OQPTJV5MjJF8wUp0o9NT8Oo6sUJ26kfgsb64FwqQh1wO5uBg==
+
+sass-embedded-android-ia32@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.80.3.tgz#3a8bbde8d05b69833ed3dd6b5ba13cb4bac31385"
+  integrity sha512-XCa4Se7vqWuV5tFLZuYWidPLUCeK7n1AgugircJl/9QPThCGZ2mSRF0Ipj3lv+Qw4GG9kkhCqJIrksTGbSFypw==
+
+sass-embedded-android-riscv64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.80.3.tgz#9cf509187f2ddeefd79fb7f68ec715d2c8386811"
+  integrity sha512-Dn3hYh5rchfivnPrHoff2pWutuFYJRddzEXcjfb0JhgF7JmTA/6Dxaym0pqVpS1RmYDiAYnmoX5OeFtEkdVytA==
+
+sass-embedded-android-x64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-android-x64/-/sass-embedded-android-x64-1.80.3.tgz#d05c26e2eef254eff75444b3fbea2b3a15aabc79"
+  integrity sha512-QWOTHKPznYJnrP3HrlFYnAQOZ/c2am4ctK1cFIMtjQNGaFra8z94LZSQzAd6eeu6mITKwQbJuff36RpICZpgHA==
+
+sass-embedded-darwin-arm64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.80.3.tgz#d4b7cd615060b57004ccef8d786e83f3a1c68ecb"
+  integrity sha512-NqJXHzZGqVOarr36X5MIv0UCQHYVhOFXGe7kDhNqMQCiNApkVydseB5TM1C2lVaiWy2JaseRD/dUNS/o2ICKXw==
+
+sass-embedded-darwin-x64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.80.3.tgz#504d9a12d381e56822f6bc69cd80a7fd4d92a120"
+  integrity sha512-6dmNn+oNxXE5uGThfAsHgz7Jg1oDhXHHQyPAnIIaMOM5dXv0D/nLmrlFbFajK0HtbzGaTVBTE6wkJwjASuP0Uw==
+
+sass-embedded-linux-arm64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.80.3.tgz#ad4ed3e40eb24419d1b98e7d7d106b4ea04dd06b"
+  integrity sha512-a9IILen4I6oFFb5qMHOiFqIAoztPuvJ6VHNaFbktP8SUvH4FX63ZutR/qKisN9DoudzSXMZijv/aG/bTh0Kccw==
+
+sass-embedded-linux-arm@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.80.3.tgz#c3a2bfedb63c57e70110c6e252240d81146f1022"
+  integrity sha512-nZ7Y8gZgr+/fYrbsX3L8BfIafWXGVBcc0gKLoujad+axlFGv1MetO17S3vzrOQ1wuhjvDLVxceA/jtcta1qxoA==
+
+sass-embedded-linux-ia32@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.80.3.tgz#266888efffd5ba6eebd163c3e1d9cf17f6e0d2d6"
+  integrity sha512-yKy4N0L9WfGokpBMHOhxzaS3jyzrHUg1+5Idi6J88onwxfpEhqOgdMcoqgOqvryMPrmKN7kW5d3iNpUYOniPnw==
+
+sass-embedded-linux-musl-arm64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.80.3.tgz#05d7a2e44db2b72200ed304d82e86686d1ac4563"
+  integrity sha512-mw4BPe42wlAwg6vgmGkg+MDDyXZBexvAWC+QigtfMjTVHuSAB527UVWhIyv4jAkKLp71mPowsXXsfa4UHzyBaA==
+
+sass-embedded-linux-musl-arm@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.80.3.tgz#5c3d617da07da7ceacfa86cd46c4a55ae3cf69af"
+  integrity sha512-yB7iSoS/phNHKFsZRW0rTRwoCTtOBELG/UYpIa2qATWZsDASSjdBitGsKS3nEliweveuGIVlUqG2kUKaq9M39g==
+
+sass-embedded-linux-musl-ia32@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.80.3.tgz#9ef3a15daace76261ae7029ab280276dc2763367"
+  integrity sha512-eyg5L9IFisCYYMXEZ/56X8k8wdhpfK06/j9MFAINE9U4C5NxQXrVWmMTEqgyfpmca8hziBlvbRrjdquteyXWfw==
+
+sass-embedded-linux-musl-riscv64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.80.3.tgz#505cf8e1b1e77b32f490004f7a8ba87187572fa2"
+  integrity sha512-0VThiW7Gwo5UNgKyETYID6F2prHvOCH8fQQKM0sS/JSbTu1poTwD35yEptVxBpiTvyWwxI7K5Cbn0gtxobaqzA==
+
+sass-embedded-linux-musl-x64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.80.3.tgz#aefa92f12751c374e4d9d2672e657b7aa593c782"
+  integrity sha512-ALSKlhTQdNS0cayyaXD8huNd+DRjWgCjDqyjvwSgemfLL+wtmVCO8h9rGu1MCwR8GHP6ceZCT2fBmjfcGHk0DQ==
+
+sass-embedded-linux-riscv64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.80.3.tgz#8bc4b8a82d5d6b91b659d1c4f74ec4a661daba4a"
+  integrity sha512-/1JvuQi137BNO7iTvNNraGYEt9mh3ch44cabJBTxLn3IZV5vNblENI+Hrj9J8/VWIsJumwPQGZSUrMbZcgB0tg==
+
+sass-embedded-linux-x64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.80.3.tgz#4d08a070a7e008b063bc5d71b8d92548bb6da96e"
+  integrity sha512-ISQUnl9oFA0PFPtgOpgotfKQ8guUBIYcTpkHEF9lQ4PyFIxkXppk5CwQ8l0VQcQaKhOD2HQAucoqM51U7FABqA==
+
+sass-embedded-win32-arm64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.80.3.tgz#a0511eda059623b51dc94a243572cbc9a1b4b797"
+  integrity sha512-RFT/OsWHVagPYa/9v+KfVM99QgzwzwnT2maapRfulEH39v0uPGOIFNXmnhaN3E5gNLIjIn3CTnR9KjTC145E8Q==
+
+sass-embedded-win32-ia32@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.80.3.tgz#f55e3cec7a2c2321212602b6e6f374ee85c1d2bc"
+  integrity sha512-Is0eeX+UlWW7yPfDqc2Z2n9ql2rkA1uDaAkbHWWx5APc8CKYtds1w4B3Tyoy6lHnopEifgzgsnp6QSyOHHzPBg==
+
+sass-embedded-win32-x64@1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.80.3.tgz#e797d2dc8597ad6541dbbccc90fd49f1f21cc563"
+  integrity sha512-wehVA0atPloc6NKof/ctpW0agM+k7kiBLIpQs3/mi9FAlmTjxNnvntBPZIbl8n7AAExiLEir+x/LHC0yGhTfkg==
+
+sass-embedded@^1.80.3:
+  version "1.80.3"
+  resolved "https://registry.yarnpkg.com/sass-embedded/-/sass-embedded-1.80.3.tgz#9b0d99605f4f9921cb432f8052d33b03312acead"
+  integrity sha512-aTxTl4ToSAWg7ILFgAe+kMenj+zNlwHmHK/ZNPrOM8+HTef1Q6zuxolptYLijmHdZHKSMOkWYHgo5MMN6+GIyg==
   dependencies:
-    "@parcel/watcher" "^2.4.1"
-    chokidar "^4.0.0"
+    "@bufbuild/protobuf" "^2.0.0"
+    buffer-builder "^0.2.0"
+    colorjs.io "^0.5.0"
     immutable "^4.0.0"
-    source-map-js ">=0.6.2 <2.0.0"
+    rxjs "^7.4.0"
+    supports-color "^8.1.1"
+    varint "^6.0.0"
+  optionalDependencies:
+    sass-embedded-android-arm "1.80.3"
+    sass-embedded-android-arm64 "1.80.3"
+    sass-embedded-android-ia32 "1.80.3"
+    sass-embedded-android-riscv64 "1.80.3"
+    sass-embedded-android-x64 "1.80.3"
+    sass-embedded-darwin-arm64 "1.80.3"
+    sass-embedded-darwin-x64 "1.80.3"
+    sass-embedded-linux-arm "1.80.3"
+    sass-embedded-linux-arm64 "1.80.3"
+    sass-embedded-linux-ia32 "1.80.3"
+    sass-embedded-linux-musl-arm "1.80.3"
+    sass-embedded-linux-musl-arm64 "1.80.3"
+    sass-embedded-linux-musl-ia32 "1.80.3"
+    sass-embedded-linux-musl-riscv64 "1.80.3"
+    sass-embedded-linux-musl-x64 "1.80.3"
+    sass-embedded-linux-riscv64 "1.80.3"
+    sass-embedded-linux-x64 "1.80.3"
+    sass-embedded-win32-arm64 "1.80.3"
+    sass-embedded-win32-ia32 "1.80.3"
+    sass-embedded-win32-x64 "1.80.3"
 
 scheduler@^0.23.2:
   version "0.23.2"
@@ -2335,7 +2344,7 @@ simple-icons@^13.14.1:
   resolved "https://registry.yarnpkg.com/simple-icons/-/simple-icons-13.14.1.tgz#12f47b4c997b68816541350f770b15e22e68745f"
   integrity sha512-Syxm5ZpLgfePbZ8TXoOgiazaUqutE48eXhY8Mix2vK0uPji2rl+A2XG/sEyPBwIVj0tZeXuWolyTtMURASswTg==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.0:
+source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
@@ -2418,6 +2427,13 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
@@ -2433,12 +2449,10 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
   integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
 
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
-  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  dependencies:
-    is-number "^7.0.0"
+tslib@^2.1.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.0.tgz#d124c86c3c05a40a91e6fdea4021bd31d377971b"
+  integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2520,6 +2534,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+varint@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
+  integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
 vite@^5.4.9:
   version "5.4.9"


### PR DESCRIPTION
## 🔀 Migrate legacy sass -> sass-embedded

Sass announced that the `@import` statements no longer works on the legacy api so this PR migrates to the new embedded sass. Read more [here](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/).

This also removes the deprecation warnings during development.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none