### PR TITLE
Improve logs dialog

### DIFF
--- a/client/src/pages/Apps/components/AppInstaller/components/LogDialog/LogDialog.jsx
+++ b/client/src/pages/Apps/components/AppInstaller/components/LogDialog/LogDialog.jsx
@@ -1,10 +1,24 @@
-import { DialogProvider } from "@/common/components/Dialog";
 import "./styles.sass";
-import { useEffect, useRef } from "react";
+import { DialogProvider } from "@/common/components/Dialog";
+import { useEffect, useRef, useState } from "react";
+import { mdiCheck, mdiContentCopy } from "@mdi/js";
+import Button from "@/common/components/Button";
 
 export const LogDialog = ({open, onClose, content}) => {
 
+    const [isCopied, toggleCopyState] = useState(false)
+
     const logRef = useRef();
+
+    const handleCopyLogs = () => {
+        toggleCopyState(true)
+
+        navigator.clipboard.writeText(content)
+
+        setTimeout(() => {
+            toggleCopyState(false)
+        }, 1500);
+    }
 
     useEffect(() => {
         if (logRef.current) {
@@ -25,6 +39,13 @@ export const LogDialog = ({open, onClose, content}) => {
                         {content}
                     </pre>
                 </div>
+
+                <Button 
+                    text={isCopied ? "Copied" : "Copy logs"}
+                    icon={isCopied ? mdiCheck : mdiContentCopy}
+                    onClick={handleCopyLogs}
+                    disabled={isCopied}
+                />
             </div>
         </DialogProvider>
     );

--- a/client/src/pages/Apps/components/AppInstaller/components/LogDialog/LogDialog.jsx
+++ b/client/src/pages/Apps/components/AppInstaller/components/LogDialog/LogDialog.jsx
@@ -34,11 +34,7 @@ export const LogDialog = ({open, onClose, content}) => {
                     <h2>Installation Log</h2>
                 </div>
 
-                <div className="log-dialog-content" ref={logRef}>
-                    <pre>
-                        {content}
-                    </pre>
-                </div>
+                <textarea className="log-dialog-content" ref={logRef} value={content} readOnly />
 
                 <Button 
                     text={isCopied ? "Copied" : "Copy logs"}

--- a/client/src/pages/Apps/components/AppInstaller/components/LogDialog/styles.sass
+++ b/client/src/pages/Apps/components/AppInstaller/components/LogDialog/styles.sass
@@ -12,13 +12,18 @@
   .log-dialog-content
     width: 100%
     box-sizing: border-box
+    user-select: text
     overflow-wrap: break-word
+    background-color: colors.$dark-gray
+    border: 1px solid colors.$gray
+    border-radius: 0.5rem
     height: 15rem
     overflow-y: auto
-    padding: 0 10px
+    padding: 0.6rem 1rem
 
     pre
       margin: 0
       white-space: pre-wrap
       font-size: 0.8rem
       font-weight: 400
+      line-height: 1.5rem

--- a/client/src/pages/Apps/components/AppInstaller/components/LogDialog/styles.sass
+++ b/client/src/pages/Apps/components/AppInstaller/components/LogDialog/styles.sass
@@ -12,18 +12,10 @@
   .log-dialog-content
     width: 100%
     box-sizing: border-box
-    user-select: text
-    overflow-wrap: break-word
     background-color: colors.$dark-gray
     border: 1px solid colors.$gray
+    color: colors.$white
     border-radius: 0.5rem
     height: 15rem
-    overflow-y: auto
+    resize: none
     padding: 0.6rem 1rem
-
-    pre
-      margin: 0
-      white-space: pre-wrap
-      font-size: 0.8rem
-      font-weight: 400
-      line-height: 1.5rem


### PR DESCRIPTION
## 📋 Description

This PR improves the log dialog when installing an application on a server. Now logs can be copied

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/497f70a7-3cca-45f0-86bc-cd7ba33b192d)

</p>
</details> 

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
