### PR TITLE
Fix organization invite failed issue

### DIFF
--- a/server/models/OrganizationMember.js
+++ b/server/models/OrganizationMember.js
@@ -9,6 +9,7 @@ module.exports = db.define("organization_members", {
     },
     accountId: {
         type: Sequelize.INTEGER,
+        primaryKey: true,
         allowNull: false,
     },
     role: {


### PR DESCRIPTION
## 📋 Description

This PR resolves a SequelizeUniqueConstraintError caused by attempting to insert duplicate organizationId values into the organization_members table. The root issue was that organizationId was incorrectly set as the primary key. Updated the schema to use a composite primary key (organizationId, accountId) to allow multiple members per organization.

## 🚀 Changes made to ...

- [V] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [V] My code follows the style guidelines of this project
- [V] I have performed a self-review of my own code
- [V] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #451 
