### PR TITLE
🪄 Tab shifting

### DIFF
--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
@@ -1,10 +1,48 @@
 import { ServerContext } from "@/common/contexts/ServerContext.jsx";
-import { useContext, useRef } from "react";
+import { useContext, useRef, useState, useEffect } from "react";
 import Icon from "@mdi/react";
 import { loadIcon } from "@/pages/Servers/components/ServerList/components/ServerObject/ServerObject.jsx";
 import { getIconByType } from "@/pages/Servers/components/ServerList/components/PVEObject/PVEObject.jsx";
 import { mdiClose, mdiViewSplitVertical } from "@mdi/js";
+import { useDrag, useDrop } from "react-dnd";
 import "./styles.sass";
+
+const DraggableTab = ({
+                          session,
+                          server,
+                          activeSessionId,
+                          setActiveSessionId,
+                          disconnectFromServer,
+                          index,
+                          moveTab,
+                      }) => {
+    const [{ isDragging }, drag] = useDrag({
+        type: "TAB",
+        item: { index, sessionId: session.id },
+        collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+    });
+
+    const [{ isOver }, drop] = useDrop({
+        accept: "TAB",
+        drop: (draggedItem) => {
+            if (draggedItem.index !== index) moveTab(draggedItem.index, index);
+        },
+        collect: (monitor) => ({ isOver: monitor.isOver() }),
+    });
+
+    return (
+        <div ref={(node) => drag(drop(node))} onClick={() => setActiveSessionId(session.id)}
+             className={`server-tab ${session.id === activeSessionId ? "server-tab-active" : ""} ${isDragging ? "dragging" : ""} ${isOver ? "drop-target" : ""}`}
+             style={{ opacity: isDragging ? 0.5 : 1 }}>
+            <Icon path={server?.icon ? loadIcon(server.icon) : getIconByType(server?.type)} />
+            <h2>{server?.name} {session.type === "sftp" ? " (SFTP)" : ""}</h2>
+            <Icon path={mdiClose} onClick={(e) => {
+                e.stopPropagation();
+                disconnectFromServer(session.id);
+            }} />
+        </div>
+    );
+};
 
 export const ServerTabs = ({
                                activeSessions,
@@ -13,16 +51,65 @@ export const ServerTabs = ({
                                disconnectFromServer,
                                layoutMode,
                                onToggleSplit,
+                               orderRef,
+                               onTabOrderChange,
                            }) => {
 
     const { getServerById, getPVEContainerById } = useContext(ServerContext);
     const tabsRef = useRef(null);
+
+    const [tabOrder, setTabOrder] = useState([]);
+
+    useEffect(() => {
+        const currentSessionIds = activeSessions.map(session => session.id);
+        const orderSessionIds = tabOrder.map(id => id);
+        const sessionsChanged = currentSessionIds.length !== orderSessionIds.length ||
+            currentSessionIds.some(id => !orderSessionIds.includes(id)) ||
+            orderSessionIds.some(id => !currentSessionIds.includes(id));
+
+        if (sessionsChanged) {
+            const newOrder = [];
+
+            tabOrder.forEach(sessionId => {
+                if (currentSessionIds.includes(sessionId)) newOrder.push(sessionId);
+            });
+
+            currentSessionIds.forEach(sessionId => {
+                if (!newOrder.includes(sessionId)) newOrder.push(sessionId);
+            });
+
+            setTabOrder(newOrder);
+
+            if (orderRef) orderRef.current = newOrder;
+            if (onTabOrderChange) onTabOrderChange(newOrder);
+        }
+    }, [activeSessions, tabOrder, orderRef]);
+
+    useEffect(() => {
+        if (orderRef && tabOrder.length > 0) orderRef.current = tabOrder;
+    }, [tabOrder, orderRef]);
 
     const handleWheel = (e) => {
         e.preventDefault();
 
         if (tabsRef.current) tabsRef.current.scrollLeft += e.deltaY;
     };
+
+    const moveTab = (fromIndex, toIndex) => {
+        if (fromIndex === toIndex) return;
+        if (fromIndex < 0 || fromIndex >= tabOrder.length || toIndex < 0 || toIndex >= tabOrder.length) return;
+
+        const newOrder = [...tabOrder];
+        const [removed] = newOrder.splice(fromIndex, 1);
+        newOrder.splice(toIndex, 0, removed);
+
+        setTabOrder(newOrder);
+
+        if (orderRef) orderRef.current = newOrder;
+        if (onTabOrderChange) onTabOrderChange(newOrder);
+    };
+
+    const orderedSessions = tabOrder.map(sessionId => activeSessions.find(session => session.id === sessionId)).filter(Boolean);
 
     return (
         <div className="server-tabs">
@@ -32,24 +119,16 @@ export const ServerTabs = ({
                       onClick={onToggleSplit} />
             </div>
             <div className="tabs" ref={tabsRef} onWheel={handleWheel}>
-                {activeSessions.map(session => {
+                {orderedSessions.map((session, index) => {
                     let server = session.containerId === undefined ? getServerById(session.server) : getPVEContainerById(session.server, session.containerId);
 
                     return (
-                        <div key={session.id}
-                             className={"server-tab" + (session.id === activeSessionId ? " server-tab-active" : "")}
-                             onClick={() => setActiveSessionId(session.id)}>
-                            <Icon path={server?.icon ? loadIcon(server.icon) : getIconByType(server?.type)} />
-                            <h2>{server?.name} {session.type === "sftp" ? " (SFTP)" : ""}</h2>
-                            <Icon path={mdiClose} onClick={(e) => {
-                                e.stopPropagation();
-                                disconnectFromServer(session.id);
-                            }} />
-                        </div>
+                        <DraggableTab key={session.id} session={session} server={server} index={index} moveTab={moveTab}
+                                      activeSessionId={activeSessionId} setActiveSessionId={setActiveSessionId}
+                                      disconnectFromServer={disconnectFromServer} />
                     );
                 })}
             </div>
         </div>
-
     );
 };

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/styles.sass
@@ -53,14 +53,24 @@
       align-items: center
       border-radius: 0.5rem 0.5rem 0 0
       border-bottom: 2px solid transparent
-      cursor: pointer
+      cursor: grab
       overflow: hidden
       white-space: nowrap
       flex-shrink: 0
+      transition: all 0.2s ease
 
       &:hover
         background-color: colors.$gray
         border-bottom: 2px solid colors.$primary-opacity
+
+      &.dragging
+        cursor: grabbing
+        transform: rotate(2deg)
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2)
+
+      &.drop-target
+        border-left: 3px solid colors.$primary
+        background-color: colors.$primary-opacity
 
       svg
         width: 1.5rem


### PR DESCRIPTION
## 🪄 Tab shifting

This feature allows you to move the order of the server tabs for organization while sessions are open. It also updates the order of the split view.

## Screenshots

![image](https://github.com/user-attachments/assets/927ea318-846c-4ee8-95bb-d077d06ded6c)


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues

Closes #29