### PR TITLE
🐛 Fix passphrase bug

### DIFF
--- a/client/src/pages/Settings/pages/Identities/components/IdentityDialog/IdentityDialog.jsx
+++ b/client/src/pages/Settings/pages/Identities/components/IdentityDialog/IdentityDialog.jsx
@@ -90,8 +90,8 @@ export const IdentityDialog = ({ open, onClose, identity }) => {
                 ...(authType === "password"
                         ? { password: password === "********" ? undefined : password }
                         : {
-                            sshKey: sshKey,
-                            passphrase: passphrase === "********" ? undefined : passphrase,
+                            sshKey: sshKey || undefined,
+                            ...(passphrase && passphrase !== "********" ? { passphrase } : {}),
                         }
                 ),
             };


### PR DESCRIPTION
## 🐛 Fix passphrase bug

The new Identities page had a bug that didn't allow saving an empty ssh key passphrase.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #554