### PR TITLE
🐛 Fix duplicating servers not working

### DIFF
--- a/server/controllers/server.js
+++ b/server/controllers/server.js
@@ -200,6 +200,7 @@ module.exports.duplicateServer = async (accountId, serverId) => {
         id: undefined,
         name: server.name + " (Copy)",
         identities: Array.isArray(server.identities) ? server.identities : JSON.parse(server.identities || "[]"),
+        config: server.config ? JSON.parse(server.config) : {},
     });
 };
 


### PR DESCRIPTION
## 🐛 Fix duplicating servers not working

Updated the `duplicateServer` function to parse the `config` property of the server object, ensuring it is correctly handled when duplicating a server.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #559