### PR TITLE
🐛 Fix old access control mechanism

### DIFF
--- a/server/utils/wsAuth.js
+++ b/server/utils/wsAuth.js
@@ -3,6 +3,7 @@ const Account = require("../models/Account");
 const Server = require("../models/Server");
 const Identity = require("../models/Identity");
 const prepareSSH = require("./prepareSSH");
+const { validateServerAccess } = require("../controllers/server");
 
 const authenticateWS = async (ws, req, options = {}) => {
     const { requiredParams = ['sessionToken', 'serverId'] } = options;
@@ -30,9 +31,15 @@ const authenticateWS = async (ws, req, options = {}) => {
         return null;
     }
 
-    const server = await Server.findOne({ where: { id: req.query.serverId, accountId: user.id } });
+    const server = await Server.findByPk(req.query.serverId);
     if (!server) {
         ws.close(4006, "The server does not exist");
+        return null;
+    }
+
+    const accessCheck = await validateServerAccess(user.id, server);
+    if (!accessCheck.valid) {
+        ws.close(4005, "You don't have access to this server");
         return null;
     }
 


### PR DESCRIPTION
## 🐛 Fix old access control mechanism

There were still usages of the old access control mechanism that just checks for accountId instead of accountId & organizationId. Changes have been made to:

- SFTP download route: `sftpDownload.js`
- App Installer / Scripts routes: `wsAuth.js`

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #570 