### PR TITLE
Remove unnecessary quotes from Docker run command in docs

### DIFF
--- a/docs/preview.md
+++ b/docs/preview.md
@@ -12,7 +12,7 @@ Since 1.0.3-OPEN-PREVIEW, you are required to set an encryption key in **hexadec
 
 ```shell
 docker run -d \
-  -e ENCRYPTION_KEY="aba3aa8e29b9904d5d8d705230b664c053415c54be20ad13be99af0057dfa23a" \
+  -e ENCRYPTION_KEY=aba3aa8e29b9904d5d8d705230b664c053415c54be20ad13be99af0057dfa23a \
   -p 6989:6989 \
   --name nexterm \
   --restart always \


### PR DESCRIPTION
## 📋 Description

Removed unnecessary quotes from Docker run command.
The quotes make the environment variable `"..."` when it's intended to be `...` and will cause errors with encryption.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [x] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

N/A
