### PR TITLE
Allow non-admin user to use ai feature

### DIFF
--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -22,7 +22,7 @@ const app = Router();
  * @return {object} 200 - AI configuration settings
  * @return {object} 403 - Admin access required
  */
-app.get("/", isAdmin, async (req, res) => {
+app.get("/", async (req, res) => {
     try {
         const settings = await getAISettings();
         res.json(settings);


### PR DESCRIPTION
## 📋 Description

Currently, even when the AI feature is enabled by an admin in the system, regular users are unable to access it. This is due to the isAdmin middleware applied to the API that retrieves AI settings.

This PR removes the isAdmin restriction from the AI settings API, allowing all authenticated users to retrieve AI configuration and properly utilize the AI functionality when it’s globally enabled.

While this change allows regular users to retrieve additional internal information (such as the backend model type and server location), it does not expose critical data like API keys, which are already excluded from the response. Therefore, there is no immediate security risk.

This approach provides a temporary solution to the current access limitation. Further refinement (e.g., response filtering or permission-based field visibility) can be addressed in a future PR.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

