### PR TITLE
🐛 Fix Ctrl+A not working in terminal

### DIFF
--- a/server/hooks/pve-lxc.js
+++ b/server/hooks/pve-lxc.js
@@ -79,8 +79,15 @@ module.exports = async (ws, context) => {
                 }
 
                 if (data.startsWith("\x01")) {
-                    const [width, height] = data.substring(1).split(",").map(Number);
-                    lxcSocket.send("1:" + width + ":" + height + ":");
+                    const resizeData = data.substring(1);
+                    if (resizeData.includes(",")) {
+                        const [width, height] = resizeData.split(",").map(Number);
+                        if (!isNaN(width) && !isNaN(height)) {
+                            lxcSocket.send("1:" + width + ":" + height + ":");
+                            return;
+                        }
+                    }
+                    lxcSocket.send("0:" + data.length + ":" + data);
                 } else {
                     lxcSocket.send("0:" + data.length + ":" + data);
                 }

--- a/server/hooks/ssh.js
+++ b/server/hooks/ssh.js
@@ -17,8 +17,15 @@ module.exports = async (ws, context) => {
 
             ws.on("message", (data) => {
                 if (data.startsWith("\x01")) {
-                    const [width, height] = data.substring(1).split(",").map(Number);
-                    stream.setWindow(height, width);
+                    const resizeData = data.substring(1);
+                    if (resizeData.includes(",")) {
+                        const [width, height] = resizeData.split(",").map(Number);
+                        if (!isNaN(width) && !isNaN(height)) {
+                            stream.setWindow(height, width);
+                            return;
+                        }
+                    }
+                    stream.write(data);
                 } else {
                     stream.write(data);
                 }


### PR DESCRIPTION
## 🐛 Fix Ctrl+A not working in terminal

Nexterm uses \x01 as a resize operator. This conflicted with Ctrl+A characters on the system. This PR fixes this issue.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues

Fixes #52