### PR TITLE
Interpret CMD as CTRL for cross-platform keybind compatibility

### DIFF
--- a/client/src/common/contexts/KeymapContext.jsx
+++ b/client/src/common/contexts/KeymapContext.jsx
@@ -10,6 +10,11 @@ export const useKeymaps = () => {
     return context;
 };
 
+const isMac = () =>
+    navigator.userAgentData
+        ? navigator.userAgentData.platform === "macOS"
+        : /Mac/i.test(navigator.userAgent);
+
 const parseKeybind = (keybind) => {
     if (!keybind) return null;
     
@@ -26,14 +31,31 @@ const parseKeybind = (keybind) => {
 
 export const matchesKeybind = (event, parsedKeybind) => {
     if (!parsedKeybind) return false;
-    
-    return (
-        event.key.toLowerCase() === parsedKeybind.key &&
-        event.ctrlKey === parsedKeybind.ctrl &&
-        event.shiftKey === parsedKeybind.shift &&
-        event.altKey === parsedKeybind.alt &&
-        event.metaKey === parsedKeybind.meta
-    );
+
+    const mac = isMac();
+
+    // key
+    if (event.key.toLowerCase() !== parsedKeybind.key) return false;
+
+    // ctrl / cmd handling
+    if (parsedKeybind.ctrl) {
+        if (mac) {
+            if (!(event.ctrlKey || event.metaKey)) return false;
+        } else {
+            if (!event.ctrlKey) return false;
+        }
+    } else {
+        if (event.ctrlKey) return false;
+    }
+
+    // meta (explicit only)
+    if (parsedKeybind.meta && !event.metaKey) return false;
+    if (!parsedKeybind.meta && event.metaKey && !parsedKeybind.ctrl) return false;
+
+    if (event.shiftKey !== parsedKeybind.shift) return false;
+    if (event.altKey !== parsedKeybind.alt) return false;
+
+    return true;
 };
 
 export const KeymapProvider = ({ children }) => {
@@ -95,7 +117,22 @@ export const KeymapProvider = ({ children }) => {
     const getKeymap = (action) => keymaps.find(k => k.action === action);
     const getKeybind = (action) => getKeymap(action)?.enabled ? getKeymap(action).key : null;
     const getParsedKeybind = (action) => parsedKeybinds[action] || null;
-    const formatKey = (key) => key ? key.split("+").map(k => k.toUpperCase()).join(" + ") : "";
+    const formatKey = (key) => {
+        if (!key) return "";
+
+        const mac = isMac();
+
+        return key
+            .split("+")
+            .map(k => {
+                if (mac && k === "ctrl") return "⌘";
+                if (k === "meta") return mac ? "⌘" : "META";
+                return k.toUpperCase();
+            })
+            .join(" + ");
+    };
+
+
 
     useEffect(() => {
         if (user) {


### PR DESCRIPTION
## 📋 Description

Adds support for interpreting the ⌘/CMD/Meta key as CTRL on macOS and correctly displays the keybind in the UI. I opted to treat the CMD key this way since keybinds are synced at the server and treating them separately would impact cross-platform compatibilty. One thing to note, however, is keybinds that are set by the user using the CMD key are not treated as a CTRL keybind, so if the user desires to maintain cross-platform compatibilty, they should define keybinds using the CTRL key.

This change may require the user to reset keybinds to work correctly. Tested working on Windows and macOS.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #882 
