### PR TITLE
Add support for docker secrets from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The server listens on port 6989 by default. You can modify this behavior using e
 
 -   `SERVER_PORT`: Server listening port (default: 6989)
 -   `NODE_ENV`: Runtime environment (development/production)
--   `ENCRYPTION_KEY`: Encryption key for passwords, SSH keys and passphrases (default: Randomly generated key)
+-   `ENCRYPTION_KEY`: Encryption key for passwords, SSH keys and passphrases. Supports Docker secrets via /run/secrets/encryption_key`
 -   `AI_SYSTEM_PROMPT`: System prompt for AI features (example: You are a Linux command generator assistant.)
 -   `LOG_LEVEL`: Logging level for application and guacd (system/info/verbose/debug/warn/error, default: system)
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,6 @@
+const { loadSecrets } = require("./utils/secrets");
+loadSecrets();
+
 const express = require("express");
 const path = require("path");
 const fs = require("fs");
@@ -85,7 +88,7 @@ if (process.env.NODE_ENV === "production") {
     );
 }
 
-if (!process.env.ENCRYPTION_KEY) throw new Error("ENCRYPTION_KEY environment variable is not set. Please set it to a random hex string.");
+if (!process.env.ENCRYPTION_KEY) throw new Error("ENCRYPTION_KEY not found. Set it via Docker secret (/run/secrets/encryption_key) or environment variable.");
 
 logger.system(`Starting Nexterm version ${packageJson.version} in ${process.env.NODE_ENV || 'development'} mode`);
 logger.system(`Running on Node.js ${process.version}`);

--- a/server/utils/secrets.js
+++ b/server/utils/secrets.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+
+const loadSecrets = (dir = "/run/secrets") => {
+    try {
+        for (const file of fs.readdirSync(dir)) {
+            const key = file.toUpperCase();
+            if (!process.env[key]) {
+                process.env[key] = fs.readFileSync(path.join(dir, file), "utf8").trim();
+            }
+        }
+    } catch {}
+};
+
+module.exports = { loadSecrets };


### PR DESCRIPTION
## Add support for docker secrets from file

Adds support to read environment variables from the /run/secrets directory.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes #794