### PR TITLE
📋 Clipboard Text Sharing in RDP

### DIFF
--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -1,5 +1,10 @@
 # 🔐 Enabling SSL/HTTPS
 
+> [!NOTE]
+> HTTPS is required for RDP clipboard sharing to work.
+
+
+
 ## 📁 Certificate Setup
 
 Place your SSL certificate files in the `data/certs` folder:

--- a/scripts/build-guacd.sh
+++ b/scripts/build-guacd.sh
@@ -51,7 +51,8 @@ start_guacd() {
     [ -n "$GUACD_PID" ] && kill $GUACD_PID 2>/dev/null && sleep 1
     echo "[guacd] Starting (log level: $GUACD_LOG_LEVEL)..."
 
-    export LD_LIBRARY_PATH="$GUACD_SRC/dist/lib:$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="$GUACD_SRC/dist/lib:$GUACD_SRC/dist/lib/freerdp2:$LD_LIBRARY_PATH"
+    export FREERDP_PLUGIN_PATH="$GUACD_SRC/dist/lib/freerdp2"
     export GUACD_HOME="$GUACD_SRC/dist"
     
     "$GUACD_SRC/src/guacd/guacd" -b 0.0.0.0 -f $GUACD_ARGS &

--- a/server/routes/guac.js
+++ b/server/routes/guac.js
@@ -28,6 +28,7 @@ module.exports = async (ws, req) => {
             enableTheming: cfg.enableTheming !== false, enableFontSmoothing: cfg.enableFontSmoothing !== false,
             enableFullWindowDrag: cfg.enableFullWindowDrag === true, enableDesktopComposition: cfg.enableDesktopComposition === true,
             enableMenuAnimations: cfg.enableMenuAnimations === true, enableAudio: cfg.enableAudio !== false,
+            enableClipboard: cfg.enableClipboard !== false,
         };
 
         let connConfig = null;

--- a/server/utils/tokenGenerator.js
+++ b/server/utils/tokenGenerator.js
@@ -27,6 +27,13 @@ module.exports.createRDPToken = (hostname, port, username, password, options = {
         "server-layout": options.keyboardLayout || "en-us-qwerty",
     };
 
+    // Keep clipboard redirection enabled unless explicitly disabled.
+    const clipboardEnabled = options.enableClipboard !== false;
+    settings["disable-clipboard"] = clipboardEnabled ? false : true;
+    settings["disable-copy"] = clipboardEnabled ? false : true;
+    settings["disable-paste"] = clipboardEnabled ? false : true;
+    if (options.clipboardEncoding) settings["clipboard-encoding"] = options.clipboardEncoding;
+
     if (options.colorDepth) settings["color-depth"] = options.colorDepth;
     if (options.resizeMethod && options.resizeMethod !== "none") settings["resize-method"] = options.resizeMethod;
 


### PR DESCRIPTION
## 📋 Description

This change adds the clipboard sharing in RDP sessions. Copy/paste now works into and out of the active RDP session.

**Important notes:** 
- This feature only works with HTTPS (valid public cert not required) as browser APIs limit this function to secure websites.
- I was unable to test with the Connector app as I could not get it to connect to my self-signed development server.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [x] 📚 Documentation
- [x] 🔄 Other: `guacd`

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1005 
