### PR TITLE
➗ Make split-view divider visible

### DIFF
--- a/client/src/pages/Servers/components/ViewContainer/ViewContainer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/ViewContainer.jsx
@@ -386,13 +386,15 @@ export const ViewContainer = ({
         const { rows, cols } = getDynamicLayout(gridSessions.length);
         const totalRowHeight = rowSizes.reduce((sum, s) => sum + s, 0) || rows;
         const resizers = [];
+        const dividerSize = 3;
+        const halfDivider = dividerSize / 2;
 
         let cumHeight = 0;
         for (let r = 0; r < rows - 1; r++) {
             cumHeight += (rowSizes[r] || 1) / totalRowHeight;
             resizers.push(
                 <div key={`h-${r}`} className="grid-resizer horizontal"
-                     style={{ position: 'absolute', top: `calc(${cumHeight * 100}% - 1.5px)`, left: 0, height: 3, width: "100%", cursor: "row-resize", zIndex: 10 }}
+                     style={{ position: 'absolute', top: `calc(${cumHeight * 100}% - ${halfDivider}px)`, left: 0, height: dividerSize, width: "100%", cursor: "row-resize", zIndex: 10 }}
                      onMouseDown={(e) => handleResizerMouseDown(e, "horizontal", r, null)} />
             );
         }
@@ -408,7 +410,7 @@ export const ViewContainer = ({
                 cumWidth += (rowCellWidths[c] || 1) / totalRowWidth;
                 resizers.push(
                     <div key={`v-${r}-${c}`} className="grid-resizer vertical"
-                         style={{ position: 'absolute', left: `calc(${cumWidth * 100}% - 1.5px)`, top: `${rowStart * 100}%`, width: 3, height: `${rowHeight * 100}%`, cursor: "col-resize", zIndex: 10 }}
+                         style={{ position: 'absolute', left: `calc(${cumWidth * 100}% - ${halfDivider}px)`, top: `${rowStart * 100}%`, width: dividerSize, height: `${rowHeight * 100}%`, cursor: "col-resize", zIndex: 10 }}
                          onMouseDown={(e) => handleResizerMouseDown(e, "vertical", c, r)} />
                 );
             }
@@ -436,8 +438,7 @@ export const ViewContainer = ({
         const spanFull = gridIndex === gridSessions.length - 1 && rowIdx === rows - 1 && gridSessions.length - (rows - 1) * cols === 1;
         const colWidth = spanFull ? 100 : (rowCellWidths[colIdx] || 1) / totalRowWidth * 100;
 
-        // Add gaps for dividers
-        const gapSize = 3; // 3px gap for dividers
+        const gapSize = 3;
         const isFirstRow = rowIdx === 0;
         const isLastRow = rowIdx === rows - 1;
         const isFirstCol = colIdx === 0;

--- a/client/src/pages/Servers/components/ViewContainer/ViewContainer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/ViewContainer.jsx
@@ -392,7 +392,7 @@ export const ViewContainer = ({
             cumHeight += (rowSizes[r] || 1) / totalRowHeight;
             resizers.push(
                 <div key={`h-${r}`} className="grid-resizer horizontal"
-                     style={{ position: 'absolute', top: `calc(${cumHeight * 100}% - 3px)`, left: 0, height: 6, width: "100%", cursor: "row-resize", zIndex: 10 }}
+                     style={{ position: 'absolute', top: `calc(${cumHeight * 100}% - 1.5px)`, left: 0, height: 3, width: "100%", cursor: "row-resize", zIndex: 10 }}
                      onMouseDown={(e) => handleResizerMouseDown(e, "horizontal", r, null)} />
             );
         }
@@ -408,7 +408,7 @@ export const ViewContainer = ({
                 cumWidth += (rowCellWidths[c] || 1) / totalRowWidth;
                 resizers.push(
                     <div key={`v-${r}-${c}`} className="grid-resizer vertical"
-                         style={{ position: 'absolute', left: `calc(${cumWidth * 100}% - 3px)`, top: `${rowStart * 100}%`, width: 6, height: `${rowHeight * 100}%`, cursor: "col-resize", zIndex: 10 }}
+                         style={{ position: 'absolute', left: `calc(${cumWidth * 100}% - 1.5px)`, top: `${rowStart * 100}%`, width: 3, height: `${rowHeight * 100}%`, cursor: "col-resize", zIndex: 10 }}
                          onMouseDown={(e) => handleResizerMouseDown(e, "vertical", c, r)} />
                 );
             }
@@ -436,7 +436,26 @@ export const ViewContainer = ({
         const spanFull = gridIndex === gridSessions.length - 1 && rowIdx === rows - 1 && gridSessions.length - (rows - 1) * cols === 1;
         const colWidth = spanFull ? 100 : (rowCellWidths[colIdx] || 1) / totalRowWidth * 100;
 
-        return { position: "absolute", top: `${rowStart}%`, left: spanFull ? 0 : `${colStart}%`, width: `${colWidth}%`, height: `${rowHeight}%`, zIndex: 1 };
+        // Add gaps for dividers
+        const gapSize = 3; // 3px gap for dividers
+        const isFirstRow = rowIdx === 0;
+        const isLastRow = rowIdx === rows - 1;
+        const isFirstCol = colIdx === 0;
+        const isLastCol = spanFull || colIdx === sessionsInRow - 1;
+
+        const topAdjust = isFirstRow ? 0 : gapSize / 2;
+        const bottomAdjust = isLastRow ? 0 : gapSize / 2;
+        const leftAdjust = isFirstCol ? 0 : gapSize / 2;
+        const rightAdjust = isLastCol ? 0 : gapSize / 2;
+
+        return { 
+            position: "absolute", 
+            top: `calc(${rowStart}% + ${topAdjust}px)`, 
+            left: spanFull ? 0 : `calc(${colStart}% + ${leftAdjust}px)`, 
+            width: spanFull ? '100%' : `calc(${colWidth}% - ${leftAdjust + rightAdjust}px)`, 
+            height: `calc(${rowHeight}% - ${topAdjust + bottomAdjust}px)`, 
+            zIndex: 1 
+        };
     };
 
     const renderAllSessions = () => activeSessions.map(session => {

--- a/client/src/pages/Servers/components/ViewContainer/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/styles.sass
@@ -122,6 +122,10 @@ $tablet: 1024px
   overflow: hidden
   -webkit-overflow-scrolling: touch
 
+  .xterm, .xterm-screen, canvas
+    padding-left: 3px
+    box-sizing: border-box
+
   &.visible
     opacity: 1
     pointer-events: auto
@@ -131,11 +135,12 @@ $tablet: 1024px
     pointer-events: none
 
 .grid-resizer
-  background: transparent
-  transition: background-color 0.2s ease
+  background: colors.$gray
+  transition: background-color 0.4s ease
   user-select: none
   flex-shrink: 0
   touch-action: none
+  opacity: 0.1
 
   @media (max-width: $tablet)
     &.vertical
@@ -150,10 +155,10 @@ $tablet: 1024px
     display: none
 
   &:hover
-    background-color: colors.$primary !important
+    opacity: 0.6
 
   &:active, .view-layouter.resizing &
-    background-color: colors.$primary !important
+    opacity: 1
 
   &.vertical
     cursor: col-resize

--- a/client/src/pages/Servers/components/ViewContainer/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/styles.sass
@@ -122,10 +122,6 @@ $tablet: 1024px
   overflow: hidden
   -webkit-overflow-scrolling: touch
 
-  .xterm, .xterm-screen, canvas
-    padding-left: 3px
-    box-sizing: border-box
-
   &.visible
     opacity: 1
     pointer-events: auto
@@ -136,7 +132,7 @@ $tablet: 1024px
 
 .grid-resizer
   background: colors.$gray
-  transition: background-color 0.4s ease
+  transition: opacity 0.2s ease
   user-select: none
   flex-shrink: 0
   touch-action: none


### PR DESCRIPTION
## 📋 Description

This change makes the split-view divider visible, as well as bumps the terminal text off from the left-edge which always bugged me.

<img width="834" height="522" alt="image" src="https://github.com/user-attachments/assets/14c3edf0-4820-49dd-8b3d-d5739bc7bcd4" />


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1056 
