### PR TITLE
⬅️ Sidebar/server list collapse and hover improvements

### DIFF
--- a/client/src/common/components/Sidebar/Sidebar.jsx
+++ b/client/src/common/components/Sidebar/Sidebar.jsx
@@ -14,7 +14,7 @@ import { getSidebarNavigation } from "@/common/utils/navigationConfig.jsx";
 import { GITHUB_URL } from "@/App.jsx";
 import { openExternalUrl } from "@/common/utils/TauriUtil.js";
 
-export const Sidebar = () => {
+export const Sidebar = ({ onToggleCollapse }) => {
     const { t } = useTranslation();
     const location = useLocation();
     const navigate = useNavigate();
@@ -23,7 +23,6 @@ export const Sidebar = () => {
     const [settingsTab, setSettingsTab] = useState("account");
     const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
     const [supportDialogOpen, setSupportDialogOpen] = useState(false);
-    const [isCollapsed, setIsCollapsed] = useState(false);
     const [userMenuOpen, setUserMenuOpen] = useState(false);
     const hoverTimeoutRef = useRef(null);
 
@@ -41,11 +40,11 @@ export const Sidebar = () => {
     const navigation = getSidebarNavigation(t);
 
     return (<>
-        <div className={`sidebar ${isCollapsed ? "collapsed" : ""}`}>
+        <div className="sidebar">
             <ActionConfirmDialog open={logoutDialogOpen} setOpen={setLogoutDialogOpen} text={t('common.sidebar.logoutConfirmText', { username: user?.username })} onConfirm={logout} />
             <div className="sidebar-top">
-                <Tooltip text={t('common.sidebar.collapseTitle')} disabled={isCollapsed}>
-                    <div className="sidebar-logo" onClick={() => setIsCollapsed(!isCollapsed)} title={t('common.sidebar.collapseTitle')}><NextermLogo size={64} /></div>
+                <Tooltip text={t('common.sidebar.collapseTitle')}>
+                    <div className="sidebar-logo nexterm-logo" onClick={onToggleCollapse} title={t('common.sidebar.collapseTitle')}><NextermLogo size={64} /></div>
                 </Tooltip>
                 <hr />
                 <nav>

--- a/client/src/common/components/Sidebar/styles.sass
+++ b/client/src/common/components/Sidebar/styles.sass
@@ -12,7 +12,7 @@ $mobile: 768px
   align-items: center
   border-right: 2px solid colors.$dark-gray
   overflow: visible
-  transition: margin-left 0.2s, box-shadow 0.2s
+  transition: box-shadow 0.2s
   left: 0
   top: 0
   z-index: 10
@@ -23,16 +23,6 @@ $mobile: 768px
 
   @media (max-width: $mobile)
     display: none
-
-  &.collapsed
-    margin-left: -5rem
-    position: absolute
-    top: var(--title-bar-height)
-    height: var(--content-height)
-
-    &:hover
-      margin-left: 0
-      box-shadow: 2px 0 10px rgba(0, 0, 0, 0.2)
 
   .sidebar-top
     display: flex

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -91,8 +91,8 @@ body.tauri-mode
   width: 15px
   height: 100%
   flex-shrink: 0
-  background-color: colors.$background
-  border-right: 1px solid colors.$background
+  background-color: colors.$lighter-background
+  border-right: 1px solid colors.$lighter-background
   cursor: pointer
   opacity: 0.6
   transition: opacity 0.15s ease, background-color 0.15s ease

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -47,6 +47,7 @@ body.tauri-mode
   width: 100vw
   overflow: hidden
   min-height: 0
+  position: relative
 
   @media (max-width: $mobile)
     padding-bottom: var(--mobile-nav-height)
@@ -54,6 +55,55 @@ body.tauri-mode
   > *
     min-width: 0
     flex-shrink: 0
+
+.left-pane
+  position: relative
+  left: 0
+  top: 0
+  height: 100%
+  display: flex
+  align-items: stretch
+  z-index: 30
+  transform: translateX(0)
+  transition: transform 0.2s ease, box-shadow 0.2s ease
+  flex-shrink: 0
+
+  &.collapsed
+    position: absolute
+    transform: translateX(-100%)
+    box-shadow: none
+    pointer-events: none
+
+  &.collapsed.open
+    transform: translateX(0)
+    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.3)
+    pointer-events: auto
+
+  &.collapsed
+    .resizer
+      display: none
+
+.left-pane-slot
+  display: flex
+  height: 100%
+
+.left-pane-hover-bar
+  width: 15px
+  height: 100%
+  flex-shrink: 0
+  background-color: colors.$background
+  border-right: 1px solid colors.$background
+  cursor: pointer
+  opacity: 0.6
+  transition: opacity 0.15s ease, background-color 0.15s ease
+  display: none
+
+  &.active
+    display: block
+
+  &:hover
+    opacity: 1
+    background-color: colors.$gray
 
 .sidebar
   width: calc(5rem + 2px)
@@ -65,6 +115,16 @@ body.tauri-mode
   overflow-y: auto
   > *
     height: 100%
+
+@media (max-width: $mobile)
+  .left-pane
+    position: static
+    transform: none
+    box-shadow: none
+    pointer-events: auto
+
+  .left-pane-hover-bar
+    display: none
 
 ::-webkit-scrollbar
   width: 13px

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -88,7 +88,7 @@ body.tauri-mode
   height: 100%
 
 .left-pane-hover-bar
-  width: 15px
+  width: 10px
   height: 100%
   flex-shrink: 0
   background-color: colors.$lighter-background

--- a/client/src/pages/Servers/Servers.jsx
+++ b/client/src/pages/Servers/Servers.jsx
@@ -1,6 +1,7 @@
 import "./styles.sass";
 import ServerList from "@/pages/Servers/components/ServerList";
 import { useContext, useEffect, useState, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 import WelcomePanel from "@/pages/Servers/components/WelcomePanel";
 import ServerDialog from "@/pages/Servers/components/ServerDialog";
 import ViewContainer from "@/pages/Servers/components/ViewContainer";
@@ -30,6 +31,7 @@ export const Servers = () => {
     const [pendingConnection, setPendingConnection] = useState(null);
     const [openFileEditors, setOpenFileEditors] = useState([]);
     const [mobileServerListOpen, setMobileServerListOpen] = useState(false);
+    const [leftPaneSlot, setLeftPaneSlot] = useState(null);
 
     const [currentFolderId, setCurrentFolderId] = useState(null);
     const [currentOrganizationId, setCurrentOrganizationId] = useState(null);
@@ -49,6 +51,10 @@ export const Servers = () => {
         const handleToggle = () => setMobileServerListOpen(prev => !prev);
         window.addEventListener('toggleServerList', handleToggle);
         return () => window.removeEventListener('toggleServerList', handleToggle);
+    }, []);
+
+    useEffect(() => {
+        setLeftPaneSlot(document.getElementById("left-pane-slot"));
     }, []);
 
     const handleConnectionsUpdate = useCallback((sessions) => {
@@ -454,19 +460,22 @@ export const Servers = () => {
                 onConnect={handleConnectionReasonProvided}
                 serverName={pendingConnection?.server?.name || "Unknown Server"}
             />
-            <ServerList setServerDialogOpen={(protocol = null) => {
-                setServerDialogProtocol(protocol);
-                setServerDialogOpen(true);
-            }}
-                        connectToServer={connectToServer}
-                        setProxmoxDialogOpen={() => setProxmoxDialogOpen(true)}
-                        setSSHConfigImportDialogOpen={() => setSSHConfigImportDialogOpen(true)}
-                        setCurrentFolderId={setCurrentFolderId} setCurrentOrganizationId={setCurrentOrganizationId}
-                        setEditServerId={setEditServerId} openSFTP={openSFTP}
-                        hibernatedSessions={hibernatedSessions} resumeSession={resumeConnection}
-                        openDirectConnect={openDirectConnect} runScript={runScript}
-                        openPortForward={isTauri() ? openPortForward : undefined}
-                        mobileOpen={mobileServerListOpen} setMobileOpen={setMobileServerListOpen} />
+            {leftPaneSlot && createPortal(
+                <ServerList setServerDialogOpen={(protocol = null) => {
+                    setServerDialogProtocol(protocol);
+                    setServerDialogOpen(true);
+                }}
+                            connectToServer={connectToServer}
+                            setProxmoxDialogOpen={() => setProxmoxDialogOpen(true)}
+                            setSSHConfigImportDialogOpen={() => setSSHConfigImportDialogOpen(true)}
+                            setCurrentFolderId={setCurrentFolderId} setCurrentOrganizationId={setCurrentOrganizationId}
+                            setEditServerId={setEditServerId} openSFTP={openSFTP}
+                            hibernatedSessions={hibernatedSessions} resumeSession={resumeConnection}
+                            openDirectConnect={openDirectConnect} runScript={runScript}
+                            openPortForward={isTauri() ? openPortForward : undefined}
+                            mobileOpen={mobileServerListOpen} setMobileOpen={setMobileServerListOpen} />,
+                leftPaneSlot
+            )}
             {visibleSessions.length === 0 && 
                 <WelcomePanel 
                     connectToServer={connectToServer} 

--- a/client/src/pages/Servers/components/ServerList/ServerList.jsx
+++ b/client/src/pages/Servers/components/ServerList/ServerList.jsx
@@ -829,7 +829,7 @@ export const ServerList = ({
                     />
                 </div>
             )}
-            {!isMobile && <div className={`resizer${isResizing ? " is-resizing" : ""}`} onMouseDown={startResizing} />}
+            {!isMobile && !isCollapsed && <div className={`resizer${isResizing ? " is-resizing" : ""}`} onMouseDown={startResizing} />}
         </div>
         </>
     );


### PR DESCRIPTION
## 📋 Description

Merges the sidebar and serverlist into a single collapsable pane with a larger hover region. Additionally, when the mouse leaves the viewport from the left side (in the case of a left-side secondary monitor), the pane still collapses.

![msedge_bsLnX22Q6t](https://github.com/user-attachments/assets/2f6676eb-8969-4db6-9988-92fad6bc7ec3)


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #990 
