### PR TITLE
📱Mobile safari optimizations

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/assets/fonts/ubuntu-mono/index.css" />
     <link rel="stylesheet" href="/assets/fonts/roboto-mono/index.css" />
     <link rel="stylesheet" href="/assets/fonts/hack-font/index.css" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1, user-scalable=no" />
     <title>Nexterm</title>
   </head>
   <body>

--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "error": "Error",
+    "info": "Info",
     "success": "Success",
     "loading": "Loading...",
     "saving": "Saving...",
@@ -174,7 +175,8 @@
       "organizationDeleted": "Organization deleted successfully",
       "organizationDeleteError": "Failed to delete organization",
       "leftOrganization": "You have left the organization",
-      "leaveOrganizationError": "Failed to leave organization"
+      "leaveOrganizationError": "Failed to leave organization",
+      "ipadosContextMenuTip": "An iPadOS webkit bug causes the native OS right-click menu to appear over the Nexterm menu. Use two-finger-click (not tap) to avoid this, or disable tap-to-click from from Settings app > General > Trackpad."
     }
   },
   "audit": {

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -4,25 +4,35 @@ $mobile: 768px
 
 :root
   --title-bar-height: 0px
-  --content-height: 100vh
+  --viewport-height: 100vh
+  --content-height: var(--viewport-height)
   --mobile-nav-height: 0px
   --safe-area-top: env(safe-area-inset-top, 0px)
 
+  @supports (height: 100dvh)
+    --viewport-height: 100dvh
+
   @media (max-width: $mobile)
     --mobile-nav-height: calc(3.5rem + env(safe-area-inset-bottom, 0px))
-    --content-height: calc(100vh - var(--safe-area-top))
 
 body, html
   margin: 0
+  height: var(--viewport-height)
+  min-height: var(--viewport-height)
+  max-height: var(--viewport-height)
   overflow: hidden
   background-color: colors.$background
   color: colors.$white
   font-family: "Plus Jakarta Sans", sans-serif
   font-weight: 700
 
+#root
+  height: 100%
+  min-height: 100%
+
 body.tauri-mode
   --title-bar-height: 32px
-  --content-height: calc(100vh - 32px)
+  --content-height: calc(var(--viewport-height) - 32px)
   -webkit-user-select: none
   -moz-user-select: none
   user-select: none
@@ -39,6 +49,7 @@ body.tauri-mode
   height: var(--content-height)
   width: 100vw
   overflow: hidden
+  box-sizing: border-box
   padding-top: var(--safe-area-top)
 
 .content-wrapper

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -25,6 +25,7 @@ body, html
   user-select: none
   overflow: hidden
   overscroll-behavior: none
+  touch-action: none
   background-color: colors.$background
   color: colors.$white
   font-family: "Plus Jakarta Sans", sans-serif

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -23,12 +23,14 @@ body, html
   -webkit-user-select: none
   -moz-user-select: none
   user-select: none
-  -webkit-touch-callout: none
   overflow: hidden
   background-color: colors.$background
   color: colors.$white
   font-family: "Plus Jakarta Sans", sans-serif
   font-weight: 700
+
+*
+  -webkit-touch-callout: none
 
 input, textarea, [contenteditable="true"], .allow-select
   -webkit-user-select: text

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -20,11 +20,21 @@ body, html
   height: var(--viewport-height)
   min-height: var(--viewport-height)
   max-height: var(--viewport-height)
+  -webkit-user-select: none
+  -moz-user-select: none
+  user-select: none
+  -webkit-touch-callout: none
   overflow: hidden
   background-color: colors.$background
   color: colors.$white
   font-family: "Plus Jakarta Sans", sans-serif
   font-weight: 700
+
+input, textarea, [contenteditable="true"], .allow-select
+  -webkit-user-select: text
+  -moz-user-select: text
+  user-select: text
+  -webkit-touch-callout: default
 
 #root
   height: 100%

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -24,6 +24,7 @@ body, html
   -moz-user-select: none
   user-select: none
   overflow: hidden
+  overscroll-behavior: none
   background-color: colors.$background
   color: colors.$white
   font-family: "Plus Jakarta Sans", sans-serif

--- a/client/src/common/styles/toast.sass
+++ b/client/src/common/styles/toast.sass
@@ -8,9 +8,9 @@
   flex-direction: column-reverse
   gap: 12px
   z-index: 10002
-  pointer-events: none
+  pointer-events: auto
   max-width: 380px
-  width: calc(100% - 96px)
+  width: min(380px, calc(100% - 96px))
 
 .toast
   display: flex

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -35,6 +35,17 @@ window.addEventListener("resize", setViewportHeight);
 window.visualViewport?.addEventListener("resize", setViewportHeight);
 window.visualViewport?.addEventListener("scroll", setViewportHeight);
 
+const preventZoomGesture = (e) => {
+    if (e.touches && e.touches.length > 1) {
+        e.preventDefault();
+    }
+};
+
+document.addEventListener("gesturestart", (e) => e.preventDefault(), { passive: false });
+document.addEventListener("gesturechange", (e) => e.preventDefault(), { passive: false });
+document.addEventListener("gestureend", (e) => e.preventDefault(), { passive: false });
+document.addEventListener("touchmove", preventZoomGesture, { passive: false });
+
 createRoot(document.getElementById("root")).render(
     <StrictMode>
         <PreferencesProvider>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,11 +3,27 @@ import { createRoot } from "react-dom/client";
 import App from "@/App.jsx";
 import { PreferencesProvider } from "@/common/contexts/PreferencesContext.jsx";
 
-document.addEventListener("contextmenu", (e) => {
-    const tag = e.target.tagName?.toLowerCase();
-    const isEditable = tag === "input" || tag === "textarea" || e.target.isContentEditable;
-    if (!isEditable) e.preventDefault();
-});
+const isEditableTarget = (target) => {
+    if (!target) return false;
+    const tag = target.tagName?.toLowerCase();
+    return tag === "input" || tag === "textarea" || target.isContentEditable;
+};
+
+const suppressNativeContextMenu = (e) => {
+    if (isEditableTarget(e.target)) return;
+    e.preventDefault();
+};
+
+document.addEventListener("contextmenu", suppressNativeContextMenu, { capture: true, passive: false });
+window.addEventListener("contextmenu", suppressNativeContextMenu, { capture: true, passive: false });
+
+const suppressRightClick = (e) => {
+    if (isEditableTarget(e.target)) return;
+    if (e.button === 2) e.preventDefault();
+};
+
+document.addEventListener("mousedown", suppressRightClick, { capture: true, passive: false });
+document.addEventListener("pointerdown", suppressRightClick, { capture: true, passive: false });
 
 const setViewportHeight = () => {
     const height = window.visualViewport?.height || window.innerHeight;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -9,6 +9,16 @@ document.addEventListener("contextmenu", (e) => {
     if (!isEditable) e.preventDefault();
 });
 
+const setViewportHeight = () => {
+    const height = window.visualViewport?.height || window.innerHeight;
+    document.documentElement.style.setProperty("--viewport-height", `${height}px`);
+};
+
+setViewportHeight();
+window.addEventListener("resize", setViewportHeight);
+window.visualViewport?.addEventListener("resize", setViewportHeight);
+window.visualViewport?.addEventListener("scroll", setViewportHeight);
+
 createRoot(document.getElementById("root")).render(
     <StrictMode>
         <PreferencesProvider>

--- a/client/src/pages/Servers/components/ViewContainer/renderer/styles/xterm.sass
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/styles/xterm.sass
@@ -14,6 +14,13 @@
       margin: 0 !important
       padding: 0 !important
 
+      @supports (-webkit-touch-callout: none)
+        .xterm-screen,
+        .xterm-helpers textarea
+          caret-color: transparent !important
+          -webkit-user-select: none
+          user-select: none
+
       .xterm-scrollable-element,
       .xterm-screen
         height: 100% !important


### PR DESCRIPTION
## 📋 Description

Improved the following on mobile safari (iOS, iPadOS):
- Scroll behavior
- Disabled text selection for UI elements (not inputs)
- Improved right-click menu handling and also added a toast upon first-time right click in mobile Safari noting a webkit and hardware trackpad bug
- Hide the native text selection carat in terminal sessions
- Disable bouncy scroll/overscroll
- Disable pinch to zoom

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

None