### PR TITLE
👉 Touch optimizations for context menus

### DIFF
--- a/client/src/common/components/ContextMenu/useContextMenu.js
+++ b/client/src/common/components/ContextMenu/useContextMenu.js
@@ -11,6 +11,9 @@ export const useContextMenu = () => {
 
         if (customPosition) {
             setPosition(customPosition);
+            if (event?.currentTarget) {
+                triggerRef.current = event.currentTarget;
+            }
         } else if (event) {
             if (event.currentTarget && event.currentTarget.getBoundingClientRect) {
                 const rect = event.currentTarget.getBoundingClientRect();

--- a/client/src/pages/Servers/components/ServerList/ServerList.jsx
+++ b/client/src/pages/Servers/components/ServerList/ServerList.jsx
@@ -261,6 +261,15 @@ export const ServerList = ({
         contextMenu.open(e, { x: e.clientX, y: e.clientY });
     };
 
+    const handleTouchContextMenu = (e, entryId, entryType = "server-object") => {
+        if (!e || e.pointerType !== "touch") return;
+        e.preventDefault();
+        e.stopPropagation();
+        setContextClickedId(entryId);
+        setContextClickedType(entryType);
+        contextMenu.open(e, { x: e.clientX, y: e.clientY });
+    };
+
     const hibernatedSessionsForServer = server ? hibernatedSessions.filter(s => s.server.id == server.id) : [];
     
     const formatSessionDate = (session) => {
@@ -483,7 +492,8 @@ export const ServerList = ({
                             onContextMenu={handleContextMenu}
                             ref={serversContainerRef}>
                             <ServerEntries entries={renameStateServers} setRenameStateId={setRenameStateId}
-                                nestedLevel={0} connectToServer={connectToServer} hibernatedSessions={hibernatedSessions} />
+                                nestedLevel={0} connectToServer={connectToServer} hibernatedSessions={hibernatedSessions}
+                                onTouchContextMenu={handleTouchContextMenu} />
                         </div>
                     )}
                     {servers && servers.length === 0 && (

--- a/client/src/pages/Servers/components/ServerList/components/ServerEntries.jsx
+++ b/client/src/pages/Servers/components/ServerList/components/ServerEntries.jsx
@@ -2,7 +2,7 @@ import ServerObject from "@/pages/Servers/components/ServerList/components/Serve
 import CollapsibleFolder from "./CollapsibleFolder.jsx";
 import OrganizationFolder from "./OrganizationFolder";
 
-const ServerEntries = ({ entries, nestedLevel, setRenameStateId, connectToServer, folderId, organizationId, hibernatedSessions = [] }) => {
+const ServerEntries = ({ entries, nestedLevel, setRenameStateId, connectToServer, folderId, organizationId, hibernatedSessions = [], onTouchContextMenu }) => {
     return (
         <>
             {entries.map(entry => {
@@ -52,6 +52,7 @@ const ServerEntries = ({ entries, nestedLevel, setRenameStateId, connectToServer
                             tags={entry.tags}
                             connectToServer={connectToServer}
                             hibernatedSessionCount={hibernatedCount}
+                            onTouchContextMenu={onTouchContextMenu}
                         />
                     );
                 }

--- a/client/src/pages/Servers/components/ServerList/components/ServerObject/ServerObject.jsx
+++ b/client/src/pages/Servers/components/ServerList/components/ServerObject/ServerObject.jsx
@@ -8,10 +8,11 @@ import { useDrag, useDrop } from "react-dnd";
 import { patchRequest } from "@/common/utils/RequestUtil.js";
 import { DropIndicator } from "../DropIndicator";
 
-export const ServerObject = ({ id, name, position, folderId, organizationId, nestedLevel, icon, type, connectToServer, status, tags = [], hibernatedSessionCount = 0 }) => {
+export const ServerObject = ({ id, name, position, folderId, organizationId, nestedLevel, icon, type, connectToServer, status, tags = [], hibernatedSessionCount = 0, onTouchContextMenu }) => {
     const { loadServers, getServerById } = useContext(ServerContext);
     const [dropPlacement, setDropPlacement] = useState(null);
     const elementRef = useRef(null);
+    const touchStartRef = useRef(null);
 
     const [{ opacity }, dragRef] = useDrag({
         item: { type: "server", id, folderId, position },
@@ -74,6 +75,21 @@ export const ServerObject = ({ id, name, position, folderId, organizationId, nes
                 dragRef(dropRef(node));
             }}
             onDoubleClick={connect}
+            onPointerDown={(e) => {
+                if (e.pointerType === "touch") {
+                    touchStartRef.current = { x: e.clientX, y: e.clientY };
+                }
+            }}
+            onPointerUp={(e) => {
+                if (e.pointerType === "touch") {
+                    const start = touchStartRef.current;
+                    const moved = start
+                        ? Math.abs(e.clientX - start.x) > 10 || Math.abs(e.clientY - start.y) > 10
+                        : false;
+                    if (!moved) onTouchContextMenu?.(e, id, "server-object");
+                    touchStartRef.current = null;
+                }
+            }}
             onMouseLeave={() => setDropPlacement(null)}>
             <DropIndicator show={isOver && dropPlacement === 'before'} placement="before" />
             <div className={


### PR DESCRIPTION
## 📋 Description

Adds the ability to open the context menu via:
1. Single tap - Server list
    - Reasoning was a single tap on the server list does not currently have a purpose, and a long press is used for reordering.
2. Single tap - Active session tab
    - Same as 1, except a single tap on an inactive tab is used to switch to the tab. I figured it is much more rare that a user would want to access the context menu of an inactive tab.
3. Long-press - Terminal view area
    - A single tap is generally used for grabbing input, and I figured a single tap for context menu would be annoying.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #994 
