### PR TITLE
📝 Add translations for server tabs context menu

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1303,6 +1303,20 @@
       "stop": "Stop",
       "start": "Start"
     },
+    "tabs": {
+      "contextMenu": {
+        "popOut": "Pop Out",
+        "startSharing": "Start Sharing",
+        "readOnly": "Read-only",
+        "readWrite": "Read & Write",
+        "copyShareLink": "Copy Share Link",
+        "changePermissions": "Change Permissions",
+        "stopSharing": "Stop Sharing",
+        "duplicate": "Duplicate",
+        "hibernateSession": "Hibernate",
+        "closeSession": "Disconnect"
+      }
+    },
     "wol": {
       "successDescription": "Magic packet sent to {{name}}",
       "errorDescription": "Failed to send magic packet"

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import Icon from "@mdi/react";
 import { mdiClose, mdiViewSplitVertical, mdiChevronLeft, mdiChevronRight, mdiSleep, mdiOpenInNew, mdiShareVariant, mdiLinkVariant, mdiPencil, mdiEye, mdiCloseCircle, mdiContentDuplicate } from "@mdi/js";
 import { useDrag, useDrop } from "react-dnd";
@@ -24,6 +25,7 @@ const DraggableTab = ({
 }) => {
     const contextMenu = useContextMenu();
     const { popOutSession } = useActiveSessions();
+    const { t } = useTranslation();
     
     const canPopOut = !session.scriptId && session.type !== "sftp";
     const canShare = canPopOut;
@@ -128,42 +130,42 @@ const DraggableTab = ({
                     <>
                         <ContextMenuItem
                             icon={mdiOpenInNew}
-                            label="Pop Out"
+                            label={t("servers.tabs.contextMenu.popOut")}
                             onClick={() => popOutSession(session.id)}
                         />
                         <ContextMenuSeparator />
                     </>
                 )}
                 {canShare && !isSharing && (
-                    <ContextMenuItem icon={mdiShareVariant} label="Start Sharing">
-                        <ContextMenuItem icon={mdiEye} label="Read-only" onClick={() => handleShare(false)} />
-                        <ContextMenuItem icon={mdiPencil} label="Read & Write" onClick={() => handleShare(true)} />
+                    <ContextMenuItem icon={mdiShareVariant} label={t("servers.tabs.contextMenu.startSharing")}>
+                        <ContextMenuItem icon={mdiEye} label={t("servers.tabs.contextMenu.readOnly")} onClick={() => handleShare(false)} />
+                        <ContextMenuItem icon={mdiPencil} label={t("servers.tabs.contextMenu.readWrite")} onClick={() => handleShare(true)} />
                     </ContextMenuItem>
                 )}
                 {canShare && isSharing && (
                     <>
-                        <ContextMenuItem icon={mdiLinkVariant} label="Copy Share Link" onClick={handleCopyLink} />
-                        <ContextMenuItem icon={mdiShareVariant} label="Change Permissions">
-                            <ContextMenuItem icon={mdiEye} label="Read-only" onClick={() => handlePermissionChange(false)} disabled={!session.shareWritable} />
-                            <ContextMenuItem icon={mdiPencil} label="Read & Write" onClick={() => handlePermissionChange(true)} disabled={session.shareWritable} />
+                        <ContextMenuItem icon={mdiLinkVariant} label={t("servers.tabs.contextMenu.copyShareLink")} onClick={handleCopyLink} />
+                        <ContextMenuItem icon={mdiShareVariant} label={t("servers.tabs.contextMenu.changePermissions")}>
+                            <ContextMenuItem icon={mdiEye} label={t("servers.tabs.contextMenu.readOnly")} onClick={() => handlePermissionChange(false)} disabled={!session.shareWritable} />
+                            <ContextMenuItem icon={mdiPencil} label={t("servers.tabs.contextMenu.readWrite")} onClick={() => handlePermissionChange(true)} disabled={session.shareWritable} />
                         </ContextMenuItem>
-                        <ContextMenuItem icon={mdiCloseCircle} label="Stop Sharing" onClick={handleStopSharing} danger />
+                        <ContextMenuItem icon={mdiCloseCircle} label={t("servers.tabs.contextMenu.stopSharing")} onClick={handleStopSharing} danger />
                         <ContextMenuSeparator />
                     </>
                 )}
                 <ContextMenuItem
                     icon={mdiContentDuplicate}
-                    label="Duplicate"
+                    label={t("servers.tabs.contextMenu.duplicate")}
                     onClick={() => duplicateSession(session.id)}
                 />
                 <ContextMenuItem
                     icon={mdiSleep}
-                    label="Hibernate Session"
+                    label={t("servers.tabs.contextMenu.hibernateSession")}
                     onClick={() => hibernateSession(session.id)}
                 />
                 <ContextMenuItem
                     icon={mdiClose}
-                    label="Close Session"
+                    label={t("servers.tabs.contextMenu.closeSession")}
                     onClick={() => closeSession(session.id)}
                     danger
                 />


### PR DESCRIPTION
## 📋 Description

Updated server tabs context menu to use translations instead of hardcoded strings. Also removed "session" from Hibernate Session for cleaniness, and changed "Close Session" to "Disconnect" for clarity.

<img width="271" height="279" alt="image" src="https://github.com/user-attachments/assets/e7a70882-4939-4fcd-a1f5-369fbc2b503d" />


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

None
