### PR TITLE
📝 File Editor Syntax Highlighting

### DIFF
--- a/client/src/common/components/FileEditorWindow/FileEditorWindow.jsx
+++ b/client/src/common/components/FileEditorWindow/FileEditorWindow.jsx
@@ -14,6 +14,76 @@ import * as monaco from "monaco-editor";
 
 loader.config({ monaco });
 
+const normalizeFilename = (filename) => filename?.toLowerCase() || "";
+
+const getMonacoLanguage = (filename) => {
+    const name = normalizeFilename(filename);
+    if (!name) return "plaintext";
+
+    const basename = name.split("/").pop() || "";
+
+    const exactNameMap = {
+        "dockerfile": "dockerfile",
+        "makefile": "makefile",
+        ".env": "ini",
+    };
+
+    if (exactNameMap[basename]) return exactNameMap[basename];
+
+    const extension = basename.includes(".") ? basename.split(".").pop() : "";
+
+    const extensionMap = {
+        js: "javascript",
+        mjs: "javascript",
+        cjs: "javascript",
+        jsx: "javascript",
+        ts: "typescript",
+        tsx: "typescript",
+        json: "json",
+        html: "html",
+        htm: "html",
+        css: "css",
+        scss: "scss",
+        sass: "scss",
+        less: "less",
+        md: "markdown",
+        markdown: "markdown",
+        yml: "yaml",
+        yaml: "yaml",
+        xml: "xml",
+        sh: "shell",
+        bash: "shell",
+        zsh: "shell",
+        py: "python",
+        go: "go",
+        java: "java",
+        c: "c",
+        h: "c",
+        cpp: "cpp",
+        cc: "cpp",
+        cxx: "cpp",
+        hpp: "cpp",
+        hxx: "cpp",
+        cs: "csharp",
+        php: "php",
+        rb: "ruby",
+        rs: "rust",
+        swift: "swift",
+        kt: "kotlin",
+        kts: "kotlin",
+        sql: "sql",
+        gql: "graphql",
+        graphql: "graphql",
+        toml: "toml",
+        ini: "ini",
+        conf: "ini",
+        env: "ini",
+        txt: "plaintext",
+    };
+
+    return extensionMap[extension] || "plaintext";
+};
+
 export const FileEditorWindow = ({ file, session, onClose, zIndex = 9999 }) => {
     const { t } = useTranslation();
     const { theme } = usePreferences();
@@ -24,6 +94,7 @@ export const FileEditorWindow = ({ file, session, onClose, zIndex = 9999 }) => {
     const [fileContentChanged, setFileContentChanged] = useState(false);
     const [unsavedChangesDialog, setUnsavedChangesDialog] = useState(false);
     const [saving, setSaving] = useState(false);
+    const [language, setLanguage] = useState("plaintext");
 
     const {
         windowRef, headerRef, isMaximized, handleMouseDown, handleResizeStart, toggleMaximize,
@@ -35,6 +106,7 @@ export const FileEditorWindow = ({ file, session, onClose, zIndex = 9999 }) => {
         setIsLoading(true);
         setFileContent("");
         setFileContentChanged(false);
+        setLanguage(getMonacoLanguage(file));
 
         const url = `/api/entries/sftp?sessionId=${session.id}&path=${file}&sessionToken=${sessionToken}`;
         downloadRequest(url).then((res) => {
@@ -132,6 +204,7 @@ export const FileEditorWindow = ({ file, session, onClose, zIndex = 9999 }) => {
                     <Editor
                         value={fileContent}
                         onChange={updateContent}
+                        language={language}
                         theme={theme === "dark" || theme === "oled" ? "vs-dark" : "vs-light"}
                         options={{
                             minimap: { enabled: false },


### PR DESCRIPTION
## 📋 Description

Adds basic syntax highlighting to the monaco SFTP file editor, based on the open file's extension.

<img width="1008" height="478" alt="image" src="https://github.com/user-attachments/assets/ecd6e5bd-e866-4817-a2c3-7cd66461178b" />


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1041 
