### PR TITLE
🐛 Fixed Provider Name Display Issue

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -844,6 +844,7 @@
     },
     "authentication": {
       "title": "{{count}} Authentication Providers",
+      "internalProviderName": "Internal Authentication",
       "addProvider": "Add Provider",
       "addLdapProvider": "Add LDAP",
       "system": "System",

--- a/client/src/pages/Settings/pages/Authentication/Authentication.jsx
+++ b/client/src/pages/Settings/pages/Authentication/Authentication.jsx
@@ -78,7 +78,7 @@ export const Authentication = () => {
                             </div>
                             <div className="details">
                                 <h3>
-                                    {provider.name}
+                                    {provider.isInternal ? t("settings.authentication.internalProviderName") : provider.name}
                                     {!!provider.isInternal && (
                                         <span className="system-badge">{t("settings.authentication.system")}</span>
                                     )}

--- a/client/src/pages/Settings/pages/Authentication/Authentication.jsx
+++ b/client/src/pages/Settings/pages/Authentication/Authentication.jsx
@@ -79,7 +79,7 @@ export const Authentication = () => {
                             <div className="details">
                                 <h3>
                                     {provider.name}
-                                    {provider.isInternal && (
+                                    {!!provider.isInternal && (
                                         <span className="system-badge">{t("settings.authentication.system")}</span>
                                     )}
                                 </h3>


### PR DESCRIPTION
## 📋 Description

The Provider name in the Authentication settings (for SSO/LDAP) showed a 0 at the end of the name. This fixes that. Additionally, it updates Internal Authentication provider to be translatable.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1091
Fixes #1076 
