### PR TITLE
🐛 Make optional passphrase optional

### DIFF
--- a/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
@@ -67,6 +67,8 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
             payload.organizationId = identity.organizationId;
         }
         
+        const hasPassphrase = typeof identity.passphrase === "string" && identity.passphrase.length > 0;
+
         if (identity.authType === 'password' || identity.authType === 'password-only') {
             if (identity.passwordTouched || identity.password) {
                 payload.password = identity.password;
@@ -76,12 +78,12 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
                 payload.password = identity.password;
             }
             payload.sshKey = identity.sshKey;
-            if (identity.passphraseTouched || identity.passphrase) {
+            if (hasPassphrase) {
                 payload.passphrase = identity.passphrase;
             }
         } else {
             payload.sshKey = identity.sshKey;
-            if (identity.passphraseTouched || identity.passphrase) {
+            if (hasPassphrase) {
                 payload.passphrase = identity.passphrase;
             }
         }

--- a/client/src/pages/Servers/components/ServerDialog/pages/IdentityPage.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/pages/IdentityPage.jsx
@@ -43,8 +43,8 @@ const Identity = ({ identity, onUpdate, onDelete, onMoveToOrg, isOrgContext, org
             ...(authType === "password" || authType === "password-only"
                 ? { password, passwordTouched: pwTouched || isNew || password !== "" }
                 : authType === "both"
-                ? { password, passwordTouched: pwTouched || isNew || password !== "", sshKey, passphrase, passphraseTouched: ppTouched || isNew || passphrase !== "" }
-                : { sshKey, passphrase, passphraseTouched: ppTouched || isNew || passphrase !== "" }),
+                ? { password, passwordTouched: pwTouched || isNew || password !== "", sshKey, passphrase, passphraseTouched: ppTouched || passphrase !== "" }
+                : { sshKey, passphrase, passphraseTouched: ppTouched || passphrase !== "" }),
         });
     }, [name, username, authType, password, sshKey, passphrase, identity.id, pwTouched, ppTouched, isNew]);
 


### PR DESCRIPTION
## 📋 Description

Resolves an issue where an ssh key passphrase was still required despite being optional in the server dialog > identity creation tab.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1114 
