### PR TITLE
✅ Highlight invalid inputs on server dialog

### DIFF
--- a/client/src/common/components/IconInput/styles.sass
+++ b/client/src/common/components/IconInput/styles.sass
@@ -25,6 +25,12 @@
   width: 100%
   outline: none
 
+  &.is-invalid
+    border: 1px solid colors.$error
+
   &:focus
     border: 1px solid colors.$primary
     background-color: colors.$dark-gray
+
+  &.is-invalid:focus
+    border: 1px solid colors.$error

--- a/client/src/common/components/SelectBox/SelectBox.jsx
+++ b/client/src/common/components/SelectBox/SelectBox.jsx
@@ -5,7 +5,7 @@ import Icon from "@mdi/react";
 import { mdiChevronDown, mdiMagnify, mdiClose } from "@mdi/js";
 import { useTranslation } from "react-i18next";
 
-export const SelectBox = ({ options, selected, setSelected, id, disabled = false, searchable = false, multiple = false, placeholder }) => {
+export const SelectBox = ({ options, selected, setSelected, id, disabled = false, searchable = false, multiple = false, placeholder, invalid = false }) => {
     const { t } = useTranslation();
     const [isOpen, setIsOpen] = useState(false);
     const [adjustedPosition, setAdjustedPosition] = useState({ top: 0, left: 0, width: 0 });
@@ -209,7 +209,7 @@ export const SelectBox = ({ options, selected, setSelected, id, disabled = false
     };
     
     return (
-        <div className={`select-box ${disabled ? 'disabled' : ''} ${multiple ? 'select-box--multiple' : ''}`} ref={selectBoxRef}>
+        <div className={`select-box ${disabled ? 'disabled' : ''} ${multiple ? 'select-box--multiple' : ''} ${invalid ? 'invalid' : ''}`} ref={selectBoxRef}>
             <div className="select-box__selected" onClick={() => !disabled && setIsOpen(!isOpen)}>
                 <div className={`select-box__selected-content ${!hasIconProperty && !multiple ? 'icon-only' : ''}`}>
                     {renderSelectedContent()}

--- a/client/src/common/components/SelectBox/styles.sass
+++ b/client/src/common/components/SelectBox/styles.sass
@@ -5,6 +5,10 @@
   user-select: none
   cursor: pointer
 
+  &.invalid
+    .select-box__selected
+      border: 1px solid colors.$error
+
   &.disabled
     cursor: not-allowed
     opacity: 0.6

--- a/client/src/common/components/TabSwitcher/TabSwitcher.jsx
+++ b/client/src/common/components/TabSwitcher/TabSwitcher.jsx
@@ -36,7 +36,7 @@ export const TabSwitcher = ({ tabs, activeTab, onTabChange, variant = "default",
                     <div
                         key={tab.key}
                         ref={el => tabRefs.current[tab.key] = el}
-                        className={`tab-switcher-tab${activeTab === tab.key ? ' active' : ''}`}
+                        className={`tab-switcher-tab${activeTab === tab.key ? ' active' : ''}${tab.isError ? ' error' : ''}`}
                         onClick={() => onTabChange(tab.key)}
                     >
                         {tab.icon && <Icon path={tab.icon} />}

--- a/client/src/common/components/TabSwitcher/styles.sass
+++ b/client/src/common/components/TabSwitcher/styles.sass
@@ -75,6 +75,9 @@
         svg
           opacity: 1
 
+      &.error
+        box-shadow: 0 0 0 1px colors.$error inset
+
       &.active
         opacity: 1
 

--- a/client/src/pages/Servers/components/ServerDialog/pages/DetailsPage.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/pages/DetailsPage.jsx
@@ -11,7 +11,7 @@ const PROTOCOL_OPTIONS = [
     { label: "VNC", value: "vnc" }
 ];
 
-const DetailsPage = ({name, setName, icon, setIcon, config, setConfig, fieldConfig}) => {
+const DetailsPage = ({name, setName, icon, setIcon, config, setConfig, fieldConfig, invalidFields = {}}) => {
     const { t } = useTranslation();
     
     return (
@@ -20,7 +20,8 @@ const DetailsPage = ({name, setName, icon, setIcon, config, setConfig, fieldConf
                 <div className="form-group">
                     <label htmlFor="name">{t("servers.dialog.fields.name")}</label>
                     <Input icon={mdiFormTextbox} type="text" placeholder={t("servers.dialog.placeholders.serverName")} 
-                           id="name" autoComplete="off" value={name} setValue={setName} />
+                              id="name" autoComplete="off" value={name} setValue={setName}
+                              customClass={invalidFields.name ? "is-invalid" : ""} />
                 </div>
                 <div className="form-group">
                     <label>{t("servers.dialog.fields.icon")}</label>
@@ -35,12 +36,13 @@ const DetailsPage = ({name, setName, icon, setIcon, config, setConfig, fieldConf
                             <label htmlFor="ip">{t("servers.dialog.fields.serverIp")}</label>
                             <Input icon={mdiIp} type="text" placeholder={t("servers.dialog.placeholders.serverIp")} 
                                    id="ip" autoComplete="off" value={config.ip || ""} 
-                                   setValue={(value) => setConfig(prev => ({ ...prev, ip: value }))} />
+                                   setValue={(value) => setConfig(prev => ({ ...prev, ip: value }))}
+                                   customClass={invalidFields.ip ? "is-invalid" : ""} />
                         </div>
                         <div className="form-group">
                             <label htmlFor="port">{t("servers.dialog.fields.port")}</label>
                             <input type="text" placeholder={t("servers.dialog.placeholders.port")} 
-                                   value={config.port || ""} className="small-input" id="port"
+                                   value={config.port || ""} className={`small-input${invalidFields.port ? " is-invalid" : ""}`} id="port"
                                    onChange={(e) => setConfig(prev => ({ ...prev, port: e.target.value }))} />
                         </div>
                     </div>
@@ -48,7 +50,8 @@ const DetailsPage = ({name, setName, icon, setIcon, config, setConfig, fieldConf
                         <div className="form-group">
                             <label>{t("servers.dialog.fields.protocol")}</label>
                             <SelectBox options={PROTOCOL_OPTIONS} selected={config.protocol} 
-                                       setSelected={(value) => setConfig(prev => ({ ...prev, protocol: value }))} />
+                                       setSelected={(value) => setConfig(prev => ({ ...prev, protocol: value }))}
+                                       invalid={invalidFields.protocol} />
                         </div>
                     )}
                     {config.wakeOnLanEnabled && (
@@ -69,14 +72,15 @@ const DetailsPage = ({name, setName, icon, setIcon, config, setConfig, fieldConf
                             <label htmlFor="nodeName">{t("servers.dialog.fields.nodeName")}</label>
                             <Input icon={mdiIp} type="text" placeholder={t("servers.dialog.placeholders.nodeName")} 
                                    id="nodeName" autoComplete="off" value={config.nodeName || ""} 
-                                   setValue={(value) => setConfig(prev => ({ ...prev, nodeName: value }))} />
+                                   setValue={(value) => setConfig(prev => ({ ...prev, nodeName: value }))}
+                                   customClass={invalidFields.nodeName ? "is-invalid" : ""} />
                         </div>
                     )}
                     {fieldConfig.pveFields.includes("vmid") && (
                         <div className="form-group">
                             <label htmlFor="vmid">{t("servers.dialog.fields.vmid")}</label>
                             <input type="text" placeholder={t("servers.dialog.placeholders.vmid")} 
-                                   value={config.vmid || ""} className="small-input" id="vmid"
+                                   value={config.vmid || ""} className={`small-input${invalidFields.vmid ? " is-invalid" : ""}`} id="vmid"
                                    onChange={(e) => setConfig(prev => ({ ...prev, vmid: e.target.value }))} />
                         </div>
                     )}

--- a/client/src/pages/Servers/components/ServerDialog/styles.sass
+++ b/client/src/pages/Servers/components/ServerDialog/styles.sass
@@ -129,9 +129,15 @@
       outline: none
       transition: border-color 0.1s ease, background-color 0.1s ease
 
+      &.is-invalid
+        border: 1px solid colors.$error
+
       &:focus
         border: 1px solid colors.$primary
         background-color: colors.$dark-gray
+
+      &.is-invalid:focus
+        border: 1px solid colors.$error
 
   .server-dialog-tabs
     display: flex

--- a/client/src/pages/Servers/components/ServerDialog/utils/fieldConfig.js
+++ b/client/src/pages/Servers/components/ServerDialog/utils/fieldConfig.js
@@ -135,20 +135,29 @@ export const getAvailableTabs = (type, protocol) => {
     return tabs;
 };
 
-export const validateRequiredFields = (type, protocol, name, config) => {
+export const getRequiredFieldErrors = (type, protocol, name, config) => {
     const fieldConfig = getFieldConfig(type, protocol);
+    const errors = {};
 
-    if (!name) return false;
+    if (!name) errors.name = true;
 
-    if (fieldConfig.showIpPort && (!config.ip || !config.port)) return false;
+    if (fieldConfig.showIpPort) {
+        if (!config.ip) errors.ip = true;
+        if (!config.port) errors.port = true;
+    }
 
-    if (fieldConfig.showProtocol && !config.protocol) return false;
+    if (fieldConfig.showProtocol && !config.protocol) errors.protocol = true;
 
     if (fieldConfig.showPveConfig && fieldConfig.pveFields) {
         for (const field of fieldConfig.pveFields) {
-            if (field === "vmid" && !config[field]) return false;
+            if (field === "vmid" && !config[field]) errors.vmid = true;
         }
     }
 
-    return true;
+    return errors;
+};
+
+export const validateRequiredFields = (type, protocol, name, config) => {
+    const errors = getRequiredFieldErrors(type, protocol, name, config);
+    return Object.keys(errors).length === 0;
 };


### PR DESCRIPTION
## 📋 Description

Adds invalid input highlighting for when the user attempts to save a server but there are validation issues. Before, the invalid input was not highlighted and only a toast appeared informing the user of some validation issue. Additionally, if the invalid input is on another tab, the tab is highlighted to indicate the user needs to switch to it and check there.

<img width="1554" height="1212" alt="image" src="https://github.com/user-attachments/assets/0537c189-2b3a-4ed8-8e88-e17ff504bbc2" />

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Related #1114 
