### PR TITLE
fix(client): use SERVER_PORT env variable for Vite API proxy target

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -40,7 +40,7 @@ export default defineConfig({
     server: {
         proxy: {
             "/api": {
-                target: "http://localhost:6989",
+                target: "http://localhost:${process.env.SERVER_PORT || 6989}",
                 ws: true
             }
         }


### PR DESCRIPTION
## 📋 Description

Currently, the Vite development server configuration (``client/vite.config.js``) hardcodes the API proxy target to ``http://localhost:6989``. If a developer configures a custom ``SERVER_PORT`` in their ``.env`` file, the frontend fails to communicate with the backend.

This PR updates the ``client/vite.config.js`` to dynamically read ``process.env.SERVER_PORT`` (falling back to the default ``6989`` if undefined). This ensures the development environment respects user configurations and improves connection reliability.

Without this fix, running the development server with a custom port or under certain Node/OS environments results in the following continuous connection drops:

```js
[1] 11:44:22 AM [vite] ws proxy error:
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:33 AM [vite] http proxy error: /api/ai
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:33 AM [vite] http proxy error: /api/accounts/me
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:33 AM [vite] http proxy error: /api/accounts/me
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:33 AM [vite] http proxy error: /api/ai
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:36 AM [vite] ws proxy error:
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:38 AM [vite] http proxy error: /api/entries/recent?limit=5
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:38 AM [vite] http proxy error: /api/entries/recent?limit=5
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:38 AM [vite] http proxy error: /api/scripts/sources
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
[1] 11:44:38 AM [vite] http proxy error: /api/scripts/sources
[1] Error: connect ECONNREFUSED 127.0.0.1:6989
[1]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
```

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

None.
