### PR TITLE
feat: Use server name as default identity name

### DIFF
--- a/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
@@ -343,7 +343,8 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
                     {activeTab === 1 && tabs[1]?.key === "identities" &&
                         <IdentityPage serverIdentities={identities} setIdentityUpdates={setIdentityUpdates}
                                       identityUpdates={identityUpdates} setIdentities={setIdentities}
-                                      currentOrganizationId={currentOrganizationId} allowedAuthTypes={fieldConfig.allowedAuthTypes} />}
+                                      currentOrganizationId={currentOrganizationId} allowedAuthTypes={fieldConfig.allowedAuthTypes}
+                                      serverName={name} />}
                     {tabs.find((tab, idx) => idx === activeTab && tab.key === "settings") && 
                         <SettingsPage config={config} setConfig={setConfig}
                                       monitoringEnabled={monitoringEnabled} setMonitoringEnabled={setMonitoringEnabled}

--- a/client/src/pages/Servers/components/ServerDialog/pages/IdentityPage.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/pages/IdentityPage.jsx
@@ -11,7 +11,7 @@ const Identity = ({ identity, onUpdate, onDelete, onMoveToOrg, isOrgContext, org
     const { t } = useTranslation();
     const isNew = !identity.id || String(identity.id).startsWith("new-");
     const isOrg = identity.scope === 'organization';
-    const [name, setName] = useState(identity.name || (isNew ? "New Identity" : ""));
+    const [name, setName] = useState(identity.name || "");
     const [username, setUsername] = useState(identity.username || "");
     const [authType, setAuthType] = useState(identity.authType || identity.type || (allowedAuthTypes?.[0] || "password"));
     const [password, setPassword] = useState(identity.password || "");
@@ -147,7 +147,7 @@ const IdentitySection = ({ title, icon, description, identities, available, onUp
     </div>
 );
 
-const IdentityPage = ({ serverIdentities, setIdentityUpdates, identityUpdates, setIdentities, currentOrganizationId, allowedAuthTypes }) => {
+const IdentityPage = ({ serverIdentities, setIdentityUpdates, identityUpdates, setIdentities, currentOrganizationId, allowedAuthTypes, serverName }) => {
     const { t } = useTranslation();
     const { identities, personalIdentities, getOrganizationIdentities, moveIdentityToOrganization } = useContext(IdentityContext);
 
@@ -185,7 +185,7 @@ const IdentityPage = ({ serverIdentities, setIdentityUpdates, identityUpdates, s
     };
     const defaultAuthType = allowedAuthTypes?.[0] || "password";
     const addNew = (forOrg) => setIdentityUpdates(prev => ({
-        ...prev, [`new-${Date.now()}`]: { name: "New Identity", username: "", authType: defaultAuthType, password: "", scope: forOrg ? 'organization' : 'personal', organizationId: forOrg ? currentOrganizationId : null }
+        ...prev, [`new-${Date.now()}`]: { name: serverName || "", username: "", authType: defaultAuthType, password: "", scope: forOrg ? 'organization' : 'personal', organizationId: forOrg ? currentOrganizationId : null }
     }));
 
     return (


### PR DESCRIPTION
Pass serverName from ServerDialog to IdentityPage and use it as the default name for newly created identities. Also remove the hardcoded "New Identity" placeholder in the Identity component so existing/new identity inputs start empty unless a serverName is provided. This aligns new identity defaults with the server context and avoids duplicate placeholder text.

## 📋 Description

This PR enhances the "Add Server" dialog by improving the default naming for new identities:

- The default name for a new identity now uses the server name from the "Details" tab, making identity names more descriptive.
- The hardcoded, untranslated "New Identity" label has been removed. This avoids untranslated strings in the UI and leverages the existing placeholder for the Identity Name field for better localization/UX.
- The serverName prop is now passed from ServerDialog to IdentityPage for this purpose.
- Users can still manually edit the identity name both during creation and at any time afterwards.

These changes help to make identity naming more contextual and localizable, improving the multilingual experience and reducing confusion from generic labels.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

<!-- Fixes #(issue) -->
