### PR TITLE
feat: Add MySQL port config

### DIFF
--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -12,7 +12,7 @@ const getCallerFromStack = () => {
     Error.prepareStackTrace = (_, stack) => stack;
     const stack = new Error().stack;
     Error.prepareStackTrace = originalPrepare;
-    
+
     for (const frame of stack) {
         const fileName = frame.getFileName();
         if (!fileName || fileName.includes('node_modules') || fileName.includes('database.js') || fileName.includes('internal/')) continue;
@@ -29,15 +29,16 @@ if (process.env.DB_TYPE === "mysql") {
 
     module.exports = new Sequelize(process.env.DB_NAME, process.env.DB_USER, process.env.DB_PASS, {
         host: process.env.DB_HOST || "localhost",
+        port: process.env.DB_PORT || 3306,
         dialect: 'mysql',
         logging: (msg) => logger.baseLogger.debug(msg, { caller: getCallerFromStack() }),
         query: {raw: true}
     });
 } else if (!process.env.DB_TYPE || process.env.DB_TYPE === "sqlite") {
     module.exports = new Sequelize({
-        dialect: 'sqlite', 
-        storage: STORAGE_PATH, 
-        logging: (msg) => logger.baseLogger.debug(msg, { caller: getCallerFromStack() }), 
+        dialect: 'sqlite',
+        storage: STORAGE_PATH,
+        logging: (msg) => logger.baseLogger.debug(msg, { caller: getCallerFromStack() }),
         query: {raw: true}
     });
 } else {


### PR DESCRIPTION
## 📋 Description

Read `DB_PORT` for MySQL connections (falls back to `3306`) so the DB port can be configured via environment. Also apply minor whitespace/formatting cleanup in server/utils/database.js for consistency (no functional changes besides the added port option).

## 🚀 Changes made to ...

- [X] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes https://github.com/gnmyt/Nexterm/issues/1097
