### PR TITLE
feat: Treat 'entry.' actions like 'server.' for Audit badges

### DIFF
--- a/client/src/pages/Settings/pages/Authentication/components/LDAPProviderDialog/LDAPProviderDialog.jsx
+++ b/client/src/pages/Settings/pages/Authentication/components/LDAPProviderDialog/LDAPProviderDialog.jsx
@@ -41,7 +41,7 @@ export const LDAPProviderDialog = ({ open, onClose, provider, onSave }) => {
                 firstNameAttribute: form.firstNameAttr, lastNameAttribute: form.lastNameAttr,
                 ...(form.bindPassword !== "********" && { bindPassword: form.bindPassword }),
             };
-            await (provider ? patchRequest(`auth/providers/admin/ldap/${provider.id}`, data) : putRequest("auth/providers/admin/ldap", { ...data, enabled: true }));
+            await (provider ? patchRequest(`auth/providers/admin/ldap/${provider.id}`, data) : putRequest("auth/providers/admin/ldap", data));
             onSave(); onClose();
         } catch (e) { sendToast("Error", e.message || T("messages.saveFailed")); }
     };

--- a/client/src/pages/Settings/pages/Authentication/components/ProviderDialog/ProviderDialog.jsx
+++ b/client/src/pages/Settings/pages/Authentication/components/ProviderDialog/ProviderDialog.jsx
@@ -73,7 +73,6 @@ export const ProviderDialog = ({ open, onClose, provider, onSave }) => {
             if (provider) {
                 await patchRequest(`auth/providers/admin/oidc/${provider.id}`, data);
             } else {
-                data.enabled = true; // New providers are enabled by default
                 await putRequest("auth/providers/admin/oidc", data);
             }
 


### PR DESCRIPTION
## 📋 Description

Extend getActionBadgeColor to handle actions starting with 'entry.' the same as 'server.'. This makes entry.connect and entry.disconnect produce the same green/orange badge colors as their server counterparts, ensuring consistent UI signaling for connect/disconnect events.

<img width="592" height="353" alt="image" src="https://github.com/user-attachments/assets/ba0b8953-79b8-4ada-b695-93cd3a112db8" />

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes https://github.com/gnmyt/Nexterm/issues/1094
