### PR TITLE
feat: Open Quick Connect for servers without identity

### DIFF
--- a/client/src/pages/Servers/Servers.jsx
+++ b/client/src/pages/Servers/Servers.jsx
@@ -142,8 +142,6 @@ export const Servers = () => {
             return;
         }
 
-        // If server has no identity assigned, open Quick Connect modal
-        // Don't show Quick Connect for PVE entries
         const isPveEntry = server?.type?.startsWith("pve-");
         const hasIdentities = server?.identities && server.identities.length > 0;
         if (server && !isPveEntry && !hasIdentities) {


### PR DESCRIPTION
## 📋 Description

When initiating a connection, automatically open the Quick Connect modal if the target server has no identities assigned. Skip this behavior for PVE entries (detected via server.type starting with "pve-"). Calls openDirectConnect(server) and returns early so the existing connection-reason flow isn't invoked.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes https://github.com/gnmyt/Nexterm/issues/1079
