### PR TITLE
fix: Consistently set default port for SSH, RDP, Telnet, VNC when adding a new server

### DIFF
--- a/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
@@ -230,13 +230,20 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
             setEntryType("server");
             
             if (initialProtocol) {
-                setConfig({ protocol: initialProtocol });
+                const portMap = { ssh: "22", telnet: "23", rdp: "3389", vnc: "5900" };
+
+                let initialConfig = { protocol: initialProtocol };
+                if (fieldConfig.showIpPort) {
+                    initialConfig.port = portMap[initialProtocol] || "";
+                }
+
+                setConfig(initialConfig);
                 const defaultIcon = PROTOCOL_DEFAULT_ICONS[initialProtocol] || null;
                 setIcon(defaultIcon);
                 initialValues.current = { 
                     name: '', 
                     icon: defaultIcon, 
-                    config: JSON.stringify({ protocol: initialProtocol }), 
+                    config: JSON.stringify(initialConfig), 
                     monitoringEnabled: false 
                 };
             } else {
@@ -248,7 +255,7 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
 
         setIdentityUpdates({});
         setActiveTab(0);
-    }, [open, editServerId, initialProtocol]);
+    }, [open, editServerId, initialProtocol, fieldConfig.showIpPort]);
 
     useEffect(() => {
         if (!open) return;
@@ -270,18 +277,6 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
         if (!editServerId) return;
         getRequest("servers/" + editServerId).then((server) => setIdentities(server.identities));
     };
-
-    useEffect(() => {
-        if (!open || !fieldConfig.showIpPort || editServerId) return;
-
-        const portMap = { ssh: "22", telnet: "23", rdp: "3389", vnc: "5900" };
-        const currentPort = config.port;
-        const expectedPort = portMap[config.protocol];
-
-        if (expectedPort && !currentPort) {
-            setConfig(prev => ({ ...prev, port: expectedPort }));
-        }
-    }, [config.protocol, open, fieldConfig.showIpPort, editServerId]);
 
     const isDirty = name !== initialValues.current.name || 
                      icon !== initialValues.current.icon ||


### PR DESCRIPTION
## 📋 Description

This PR addresses an issue where the default port (22 for SSH, 3389 for RDP, etc.) was not reliably pre-filled in the "Add Server" modal after the first use. Now, the port field is always initialized to the correct default value every time the modal is opened for protocols that require it.

- The default port is now explicitly set during modal initialization (when `setConfig` is called on open) instead of relying on a side-effect hook.
- Port initialization is conditional based on `fieldConfig.showIpPort`. For SSH, RDP, Telnet, and VNC, the port field will be set to the appropriate default (`22`, `3389`, etc.).
- Guarantees the port field is always set to its default value whenever a new server modal opens, regardless of how many times the user opens or closes it.
- Prevents the modal from being wrongly flagged as "dirty" when opened for a new server.

### Tests

- [x] Open the "Add SSH Server" modal multiple times in a row — port field should always default to 22.
- [x] Try other protocol types (RDP, Telnet, VNC) — port field should show the correct default for each.
- [x] Verify that when editing an existing server, the port remains unchanged.
- [x] The modal is no longer marked as "dirty" upon opening for a new server.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes https://github.com/gnmyt/Nexterm/issues/1176
