### PR TITLE
fix: Reload servers list after create/join/leave/delete organization

### DIFF
--- a/client/src/pages/Settings/pages/Organizations/Organizations.jsx
+++ b/client/src/pages/Settings/pages/Organizations/Organizations.jsx
@@ -17,8 +17,8 @@ import "./styles.sass";
 export const Organizations = () => {
     const { t } = useTranslation();
     const { sendToast } = useToast();
-
     const { loadServers } = useContext(ServerContext);
+
     const [organizations, setOrganizations] = useState([]);
     const [pendingInvitations, setPendingInvitations] = useState([]);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);


### PR DESCRIPTION
## 📋 Description

Import ServerContext and useContext to access loadServers, then call await loadServers() after successfully creating an organization. This ensures server data is refreshed when organizations change. Also adds the ServerContext import.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes https://github.com/gnmyt/Nexterm/issues/1092
