### PR TITLE
🐛 Keyboard shortcuts don't work on session resume

### DIFF
--- a/client/src/pages/Servers/components/ViewContainer/renderer/GuacamoleRenderer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/GuacamoleRenderer.jsx
@@ -37,11 +37,6 @@ const GuacamoleRenderer = ({
         onFullscreenToggleRef.current = onFullscreenToggle;
     }, [onFullscreenToggle]);
 
-    useEffect(() => {
-        if (registerGuacamoleRef && clientRef.current) registerGuacamoleRef(session.id, { client: clientRef.current });
-        return () => registerGuacamoleRef?.(session.id, null);
-    }, [session.id, registerGuacamoleRef, clientRef.current]);
-
     const applyDisplayStyles = (el, x, y, scale) => Object.assign(el.style, {
         position: "absolute", width: el.clientWidth + "px", height: el.clientHeight + "px",
         transform: `translate(${x}px, ${y}px) scale(${scale})`, transformOrigin: "0 0",
@@ -111,9 +106,13 @@ const GuacamoleRenderer = ({
 
     const connect = () => {
         if (isShared) {
-            if (!session.shareId || clientRef.current) return;
+            if (!session.shareId) return;
         } else {
-            if (!sessionToken || clientRef.current) return;
+            if (!sessionToken) return;
+        }
+        if (clientRef.current) {
+            registerGuacamoleRef?.(session.id, { client: clientRef.current });
+            return;
         }
         let isCleaningUp = false;
         const tunnelUrl = getWebSocketUrl("/api/ws/guac/", {});
@@ -132,8 +131,8 @@ const GuacamoleRenderer = ({
                 clientOnInstruction(opcode, args);
             }
         };
-
-        clientRef.current = client;
+    clientRef.current = client;
+    registerGuacamoleRef?.(session.id, { client });
         const display = client.getDisplay().getElement();
         display.style.position = "absolute";
         display.style.imageRendering = "crisp-edges";
@@ -200,6 +199,7 @@ const GuacamoleRenderer = ({
             client.onstatechange = tunnel.onstatechange = tunnel.onerror = null;
             audioPlayersRef.current = [];
             tunnel.disconnect();
+            registerGuacamoleRef?.(session.id, null);
             clientRef.current = null;
         };
     };


### PR DESCRIPTION
## 📋 Description

When a session resumes, either due to page refresh or other timeout, keyboard shortcuts no longer work.  This PR updates guacamole connection handling so keyboard shortcut dispatch always targets the current client after a reconnect.

- When connecting, immediately register the active guacamole client (including when an existing client is reused) so guacamoleRefs stays current for shortcut/snippet sends.
- On teardown, clear the registered client reference alongside tunnel cleanup to avoid stale mappings.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

None
