### PR TITLE
Shortcuts menu on RDP ServerTabs

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1318,6 +1318,7 @@
         "copyShareLink": "Copy Share Link",
         "changePermissions": "Change Permissions",
         "stopSharing": "Stop Sharing",
+        "keyboardShortcuts": "Shortcuts",
         "duplicate": "Duplicate",
         "hibernateSession": "Hibernate",
         "closeSession": "Disconnect"

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
@@ -1,9 +1,10 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "@mdi/react";
-import { mdiClose, mdiViewSplitVertical, mdiChevronLeft, mdiChevronRight, mdiSleep, mdiOpenInNew, mdiShareVariant, mdiLinkVariant, mdiPencil, mdiEye, mdiCloseCircle, mdiContentDuplicate } from "@mdi/js";
+import { mdiClose, mdiViewSplitVertical, mdiChevronLeft, mdiChevronRight, mdiSleep, mdiOpenInNew, mdiShareVariant, mdiLinkVariant, mdiPencil, mdiEye, mdiCloseCircle, mdiContentDuplicate, mdiKeyboard } from "@mdi/js";
 import { useDrag, useDrop } from "react-dnd";
 import TerminalActionsMenu from "../TerminalActionsMenu";
+import { KEYBOARD_SHORTCUTS } from "../TerminalActionsMenu/components/KeyboardShortcutsMenu/KeyboardShortcutsMenu.jsx";
 import { ContextMenu, ContextMenuItem, ContextMenuSeparator, useContextMenu } from "@/common/components/ContextMenu";
 import { useActiveSessions } from "@/common/contexts/SessionContext.jsx";
 import { postRequest, deleteRequest, patchRequest } from "@/common/utils/RequestUtil";
@@ -19,6 +20,7 @@ const DraggableTab = ({
     closeSession,
     hibernateSession,
     duplicateSession,
+    onKeyboardShortcut,
     index,
     moveTab,
     progress = 0,
@@ -30,6 +32,7 @@ const DraggableTab = ({
     const canPopOut = !session.scriptId && session.type !== "sftp";
     const canShare = canPopOut;
     const isSharing = !!session.shareId;
+    const isRdp = session.server?.protocol === "rdp";
 
     const handleShare = useCallback(async (writable) => {
         const result = await postRequest(`connections/${session.id}/share`, { writable });
@@ -159,7 +162,24 @@ const DraggableTab = ({
                             <ContextMenuItem icon={mdiPencil} label={t("servers.tabs.contextMenu.readWrite")} onClick={() => handlePermissionChange(true)} disabled={session.shareWritable} />
                         </ContextMenuItem>
                         <ContextMenuItem icon={mdiCloseCircle} label={t("servers.tabs.contextMenu.stopSharing")} onClick={handleStopSharing} danger />
+                        {!isRdp && <ContextMenuSeparator />}
+                    </>
+                )}
+                {isRdp && (
+                    <>
                         <ContextMenuSeparator />
+                        <ContextMenuItem
+                            icon={mdiKeyboard}
+                            label={t("servers.tabs.contextMenu.keyboardShortcuts")}
+                        >
+                            {KEYBOARD_SHORTCUTS.map((shortcut, index) => (
+                                <ContextMenuItem
+                                    key={index}
+                                    label={shortcut.label}
+                                    onClick={() => onKeyboardShortcut?.(shortcut.keys)}
+                                />
+                            ))}
+                        </ContextMenuItem>
                     </>
                 )}
                 <ContextMenuItem
@@ -325,6 +345,7 @@ export const ServerTabs = ({
                             <DraggableTab key={session.id} session={session} server={session.server} index={index} moveTab={moveTab}
                                 activeSessionId={activeSessionId} setActiveSessionId={setActiveSessionId}
                                 closeSession={closeSession} hibernateSession={hibernateSession} duplicateSession={duplicateSession}
+                                onKeyboardShortcut={onKeyboardShortcut}
                                 progress={sessionProgress[session.id] || 0} />
                         );
                     })}

--- a/client/src/pages/Servers/components/ViewContainer/components/TerminalActionsMenu/components/KeyboardShortcutsMenu/KeyboardShortcutsMenu.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/TerminalActionsMenu/components/KeyboardShortcutsMenu/KeyboardShortcutsMenu.jsx
@@ -4,7 +4,7 @@ import Icon from "@mdi/react";
 import { mdiMagnify } from "@mdi/js";
 import "./styles.sass";
 
-const KEYBOARD_SHORTCUTS = [
+export const KEYBOARD_SHORTCUTS = [
     { label: "Ctrl+Alt+Del", keys: [0xffe3, 0xffe9, 0xffff], category: "System" },
     { label: "Alt+Tab", keys: [0xffe9, 0xff09], category: "Windows" },
     { label: "Windows Key", keys: [0xffeb], category: "Windows" },


### PR DESCRIPTION
## 📋 Description

Adds the shortcuts menu to ServerTabs. This PR replaces #1060.

<img width="488" height="555" alt="image" src="https://github.com/user-attachments/assets/7a04be6b-e659-4656-9378-75b3fcd210c0" />


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

None
