### PR TITLE
feat: Add autocomplete="off" to Bind DN/Password and userSearchFilter inputs in LDAPProviderDialog

### DIFF
--- a/client/src/pages/Settings/pages/Authentication/components/LDAPProviderDialog/LDAPProviderDialog.jsx
+++ b/client/src/pages/Settings/pages/Authentication/components/LDAPProviderDialog/LDAPProviderDialog.jsx
@@ -79,12 +79,12 @@ export const LDAPProviderDialog = ({ open, onClose, provider, onSave }) => {
 
                 <div className="form-group">
                     <label>{T("fields.bindDN")}</label>
-                    <Input icon={mdiAccountMultiple} placeholder={T("fields.bindDNPlaceholder")} value={form.bindDN} setValue={set("bindDN")} />
+                    <Input icon={mdiAccountMultiple} placeholder={T("fields.bindDNPlaceholder")} value={form.bindDN} setValue={set("bindDN")} autoComplete="off" />
                 </div>
 
                 <div className="form-group">
                     <label>{T("fields.bindPassword")}</label>
-                    <Input icon={mdiKey} type="password" placeholder={provider ? T("fields.bindPasswordPlaceholderEdit") : T("fields.bindPasswordPlaceholder")} value={form.bindPassword} setValue={set("bindPassword")} />
+                    <Input icon={mdiKey} type="password" placeholder={provider ? T("fields.bindPasswordPlaceholderEdit") : T("fields.bindPasswordPlaceholder")} value={form.bindPassword} setValue={set("bindPassword")} autoComplete="off" />
                 </div>
 
                 <div className="form-group">


### PR DESCRIPTION
## 📋 Description

When configuring LDAP integration, browser-based password managers (specifically Bitwarden) incorrectly identify the Bind DN/Password and User Search Filter fields as login credentials.

Browser autocomplete on the userSearchFilter field is inappropriate — it's an LDAP filter expression (e.g. (uid={{username}})), not a user-facing value that benefits from history suggestions.

When navigating to the LDAP Configuration page, Bitwarden and other password managers should ignore these fields entirely, leaving the LDAP search strings intact and preventing accidental credential leakage into the filter configuration.

- `LDAPProviderDialog.jsx`: adds `autoComplete="off"` to the `userSearchFilter` `Input` only; all other fields are unchanged

```jsx
<Input
  icon={mdiFilter}
  placeholder={T("fields.userSearchFilterPlaceholder")}
  value={form.userSearchFilter}
  setValue={set("userSearchFilter")}
  autoComplete="off"   // ← added
/>
```

The `IconInput` component already forwards `autoComplete` to the underlying `<input>` element, so no changes to shared components are needed.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [X] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [X] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

None.