### PR TITLE
fix: Synchronize SSH timeouts to 20s to prevent premature connection drops

### DIFF
--- a/server/routes/term.js
+++ b/server/routes/term.js
@@ -33,7 +33,7 @@ module.exports = async (ws, req) => {
     if (!serverSession) return ws.close(4007, "Session required");
 
     SessionManager.resume(serverSession.sessionId);
-    const connectionTimeout = protocol === "ssh" ? 30000 : 5000;
+    const connectionTimeout = protocol === "ssh" ? 20000 : 5000;
     const { conn, sessionRemoved } = await waitForConnection(serverSession.sessionId, connectionTimeout);
     
     if (!conn) {

--- a/server/routes/term.js
+++ b/server/routes/term.js
@@ -33,7 +33,7 @@ module.exports = async (ws, req) => {
     if (!serverSession) return ws.close(4007, "Session required");
 
     SessionManager.resume(serverSession.sessionId);
-    const connectionTimeout = protocol === "ssh" ? 60000 : 5000;
+    const connectionTimeout = protocol === "ssh" ? 30000 : 5000;
     const { conn, sessionRemoved } = await waitForConnection(serverSession.sessionId, connectionTimeout);
     
     if (!conn) {

--- a/server/routes/term.js
+++ b/server/routes/term.js
@@ -33,7 +33,8 @@ module.exports = async (ws, req) => {
     if (!serverSession) return ws.close(4007, "Session required");
 
     SessionManager.resume(serverSession.sessionId);
-    const { conn, sessionRemoved } = await waitForConnection(serverSession.sessionId, 5000);
+    const connectionTimeout = protocol === "ssh" ? 60000 : 5000;
+    const { conn, sessionRemoved } = await waitForConnection(serverSession.sessionId, connectionTimeout);
     
     if (!conn) {
         if (!sessionRemoved) {

--- a/server/utils/jumpHostHelper.js
+++ b/server/utils/jumpHostHelper.js
@@ -5,7 +5,7 @@ const EntryIdentity = require("../models/EntryIdentity");
 const Identity = require("../models/Identity");
 
 const buildSSHOptions = (identity, credentials, entryConfig) => {
-    const base = { host: entryConfig.ip, port: entryConfig.port, username: identity.username, tryKeyboard: true };
+    const base = { host: entryConfig.ip, port: entryConfig.port, username: identity.username, tryKeyboard: true, readyTimeout: 30000 };
     
     if (identity.type === "password" || identity.type === "password-only") {
         return { ...base, password: credentials.password };

--- a/server/utils/jumpHostHelper.js
+++ b/server/utils/jumpHostHelper.js
@@ -5,7 +5,7 @@ const EntryIdentity = require("../models/EntryIdentity");
 const Identity = require("../models/Identity");
 
 const buildSSHOptions = (identity, credentials, entryConfig) => {
-    const base = { host: entryConfig.ip, port: entryConfig.port, username: identity.username, tryKeyboard: true, readyTimeout: 30000 };
+    const base = { host: entryConfig.ip, port: entryConfig.port, username: identity.username, tryKeyboard: true };
     
     if (identity.type === "password" || identity.type === "password-only") {
         return { ...base, password: credentials.password };


### PR DESCRIPTION
## 📋 Description

Currently, SSH connections that require longer cryptographic handshakes (such as connecting to legacy equipment that utilizes slow DH GEX math) are failing prematurely. This is caused by mismatched timeout limits across the application stack:

1. `server/routes/term.js` enforces a strict 5000ms (5-second) timeout for all incoming terminal WebSocket connections.
2. The underlying `ssh2` library defaults to a `readyTimeout` of 20,000ms (20 seconds).

Because `ssh2` was defaulting to 20 seconds, and the WebSocket router (`term.js`) was hardcoded to 5 seconds, the application was tearing down the session long before the 30-second wrappers in `jumpHostHelper.js` or `ConnectionService.js` ever got a chance to finish waiting for those slow legacy handshakes.

Because these limits are lower than the time it takes to negotiate some complex key exchanges, valid connections are being aggressively killed with a `Connection timeout, removing session` warning before the handshake completes.

## Changes

This PR synchronizes the SSH timeout limits across the stack to a standard 20 seconds (20,000ms), aligning them with the existing `ssh2` library.

1. `server/routes/term.js`: Conditionally increased the `waitForConnection` timeout to 20,000ms specifically for the `ssh` protocol. Other protocols (like `telnet` and `pve-lxc`) retain the fast 5000ms timeout.

## 🚀 Changes made to ...

- [X] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

#1227
