### PR TITLE
fix(ssh/telnet): resolve terminal hang on passive consoles and legacy devices

### DIFF
--- a/server/utils/sshEventHandlers.js
+++ b/server/utils/sshEventHandlers.js
@@ -49,35 +49,4 @@ const setupSSHEventHandlers = (ssh, ws, options) => {
     });
 };
 
-/**
- * Triggers a passive SSH session by sending a newline character.
- * * Inspired by Netmiko's session establishment. Passive proxies (OCI)
- * and legacy devices (Cisco/HP) often remain silent until they receive input.
- * This function acts as a behavioral trigger to ensure the data stream begins,
- * followed by an ANSI escape sequence to clear the terminal. Since the reset
- * uses ANSI codes, it is handled by the terminal emulator (xterm.js), not the
- * remote shell, so it works even if the device doesn't have a clear command,
- * ensuring compatibility without relying on shell-specific commands.
- * * Note: Most Linux servers send their banner/MOTD in < 50ms; they will never
- * trigger this function as the data listener clears this timer immediately.
- * * @param {Object} stream - The SSH2 channel stream.
- * @param {number} [timeoutMs=300] - Wait time before triggering.
- * @returns {NodeJS.Timeout} - The timer instance for external cleanup.
- */
-function triggerPassiveSession(stream, timeoutMs = 300) {
-    const triggerTimer = setTimeout(() => {
-        if (stream.writable) {
-            stream.write('\x0A\x1B[2J\x1B[H');
-        }
-    }, timeoutMs);
-
-    const cleanup = () => clearTimeout(triggerTimer);
-
-    // Self-destruct logic: the timer dies if data arrives,
-    // an error occurs, or the stream closes.
-    stream.once("data", cleanup);
-    stream.once("error", cleanup);
-    stream.once("close", cleanup);
-}
-
-module.exports = { parseResizeMessage, setupSSHEventHandlers, triggerPassiveSession };
+module.exports = { parseResizeMessage, setupSSHEventHandlers };


### PR DESCRIPTION
## 📋 Description

This PR fixes a critical issue where the terminal fails to initialize or open when connecting to passive environments, such as the Serial Consoles (OCI/AWS/GCP), Terminal Servers (Digi/Cyclades), and Legacy Network Switches (Cisco/HP/3Com).

## The Problem: The "Silence Deadlock"
Nexterm's connection logic (both for SSH and Telnet) appears to be reactive, often waiting for the first stream of data from the remote host to fully transition the UI from a "Connecting" state to an active session.

Many serial-over-network bridges and legacy devices remain completely silent until they receive an initial "Enter" from the client. This creates a deadlock:

1. The socket connection is technically established.
2. The server waits for client input to show a prompt.
3. The Nexterm UI remains stuck (or fails to open the terminal window) because it hasn't received the initial data event from the server.

### The Solution: Proactive Session Trigger
Inspired by [Netmiko's](https://github.com/ktbyers/netmiko/blob/develop/netmiko/base_connection.py) session establishment mechanism (`_test_channel_read`), I've implemented a `triggerPassiveSession` helper in `ConnectionService.js`.

How it works:

- **Initialization Nudge**: If no data is received within 300ms of the connection being established, the function proactively sends a newline (`\x0A`).
- **UI Wake-up**: This newline forces the remote buffer to flush, triggering the data event that Nexterm needs to successfully initialize and open the terminal UI.
- **Clean Start**: The nudge is followed by an ANSI escape sequence (`\x1B[2J\x1B[H`) to clear the terminal. This ensures that the user starts with a clean, professional-looking terminal.

### Safety & Performance
- **Self-Cleaning**: The internal timer is automatically cleared upon the first data, error, or close event, preventing any "ghost" inputs.
- **Transparent for Standard Servers**: Most Linux servers provide a banner/MOTD in < 100ms. In these cases, the timer is destroyed before firing, making the fix completely invisible and non-intrusive for standard SSH/Telnet connections.

## 🚀 Changes made to ...

- [X] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have looked for similar pull requests in the repository and found none
- [ ] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

<!-- Fixes #(issue) -->
