### PR TITLE
feat: Add Windows Server monitoring support via PowerShell over SSH

### DIFF
--- a/server/utils/monitoringService.js
+++ b/server/utils/monitoringService.js
@@ -76,7 +76,7 @@ const detectOS = async (conn) => {
     } catch {}
     try {
         const result = await executeCommand(conn, 'powershell -NoProfile -Command "(Get-WmiObject Win32_OperatingSystem).Caption"');
-        if (result && result.toLowerCase().includes("windows")) return "windows";
+        if (result?.toLowerCase().includes("windows")) return "windows";
     } catch {}
     return "unknown";
 };
@@ -282,7 +282,7 @@ const getWindowsNetworkInterfaces = async (conn) => {
                 mac: mac || null,
                 state: (state || "").toLowerCase().trim(),
                 mtu: null,
-                speed: speed ? Number.parseInt(speed.replace(/\D/g, "")) / 1000000 : null,
+                speed: speed ? Number.parseInt(speed.replaceAll(/\D/g, "")) / 1000000 : null,
                 rxBytes: Number.parseInt(rx) || 0,
                 txBytes: Number.parseInt(tx) || 0,
                 ipv4: ipv4 ? [ipv4] : [],


### PR DESCRIPTION
## What this PR does

Adds Windows Server monitoring support to the monitoring service. 
Currently all metric collection uses Linux-specific commands (`/proc/stat`, 
`free -b`, `lsblk`, etc.), which causes N/A for all metrics on Windows hosts.

## Approach

- Detects OS on connect by attempting to read `/proc/version` (Linux succeeds, Windows fails)
- If Windows is detected, runs PowerShell equivalents via SSH for all metrics
- Falls back to existing Linux collection path unchanged
- Load Average returns `null` on Windows (no equivalent concept)


## Windows metrics implemented

| Metric | PowerShell command |
|---|---|
| CPU Usage | `Get-WmiObject Win32_Processor` |
| Memory | `Get-WmiObject Win32_OperatingSystem` |
| Uptime | `gcim Win32_OperatingSystem LastBootUpTime` |
| Disk | `Get-WmiObject Win32_LogicalDisk` |
| Processes | `Get-Process` |
| OS Info | `Win32_OperatingSystem + Win32_ComputerSystem` |
| Network | `Get-NetAdapter + Get-NetAdapterStatistics` |

## Tested on

- Windows Server 2022 Datacenter (via Azure)
- Ubuntu 24.04 (existing Linux monitoring unaffected)
- Debian 12 (existing Linux monitoring unaffected)

<img width="2273" height="1146" alt="Screenshot" src="https://github.com/user-attachments/assets/3fe8dc9a-39f2-4231-b179-4a0e66934fd5" />