### PR TITLE
Security: WebSocket authentication token exposed in URL query string

### DIFF
--- a/client/src/common/hooks/useStateStream.js
+++ b/client/src/common/hooks/useStateStream.js
@@ -21,7 +21,7 @@ export const useStateStream = (sessionToken, handlers = {}) => {
     
     useEffect(() => { handlersRef.current = handlers; }, [handlers]);
 
-    const wsUrl = sessionToken ? getWebSocketUrl("/api/ws/state", { sessionToken, tabId: getTabId(), browserId: getBrowserId() }) : null;
+    const wsUrl = sessionToken ? getWebSocketUrl("/api/ws/state", { tabId: getTabId(), browserId: getBrowserId() }) : null;
     
     const onOpen = useCallback(() => {
         hasConnectedRef.current = true;


### PR DESCRIPTION
## Summary

Security: WebSocket authentication token exposed in URL query string

## Problem

**Severity**: `High` | **File**: `client/src/common/hooks/useStateStream.js:L22`

The state-stream WebSocket URL includes `sessionToken` as a query parameter. Query-string tokens are commonly logged by reverse proxies, load balancers, browser/network tooling, and server access logs, increasing credential exposure risk. If leaked, this token can be replayed to hijack sessions.

## Solution

Avoid placing long-lived auth tokens in URLs. Use secure HttpOnly cookies for WebSocket auth, or exchange the session token for a short-lived, single-use WS token before connecting. Ensure server-side logs redact sensitive query parameters if unavoidable.

## Changes

- `client/src/common/hooks/useStateStream.js` (modified)