### PR TITLE
fix(mobile): restore card outline in monitoring tab with dynamic colors

### DIFF
--- a/mobile/lib/screens/monitoring_screen.dart
+++ b/mobile/lib/screens/monitoring_screen.dart
@@ -154,7 +154,11 @@ class MonitoringScreenState extends State<MonitoringScreen> {
       padding: const EdgeInsets.symmetric(vertical: 3),
       child: Material(
         color: cs.surfaceContainerHigh,
-        borderRadius: BorderRadius.circular(16),
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(color: cs.outlineVariant, width: 1),
+        ),
         child: InkWell(
           borderRadius: BorderRadius.circular(16),
           onTap: () => _loadDetails(s),


### PR DESCRIPTION
Replaces bare `borderRadius` on the `Material` widget in `_serverCard()` with a `RoundedRectangleBorder` shape that includes a `BorderSide` using `cs.outlineVariant`. This ensures server cards always render a visible outline regardless of which color scheme is active.

**Root cause:** The card relied on implicit contrast between `surfaceContainerHigh` and the page background. With a seed-based theme this happened to look fine, but dynamic colors (derived from the system wallpaper) can produce values where `surfaceContainerHigh` is nearly identical to `surface`, making cards invisible. `cs.outlineVariant` is always defined in both static and dynamic `ColorScheme` instances, so using it as a border is reliable in both modes.

## 📋 Description

Server card borders/outlines disappear on the Monitoring tab when the Dynamic Colorsoption is enabled. Fixed by giving the `Material` widget an explicit shaped bordervia `cs.outlineVariant` and adding `clipBehavior: Clip.antiAlias` so the InkWell ripple still respects the rounded corners.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [x] 🔄 Other: 📱 Mobile (Flutter)

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues

Fixes #1431
