### PR TITLE
fix(ssh): intercept DSR cursor queries to prevent pwsh CPR garbage ou…

### DIFF
--- a/server/hooks/ssh.js
+++ b/server/hooks/ssh.js
@@ -7,6 +7,8 @@ const { SCRIPT_MAGIC } = require("../lib/ScriptLayer");
 
 const bindHandlers = (ws, conn, sessionId, config, isShared) => {
     const { dataSocket, scriptLayer } = conn;
+    let termCols = 80;
+    let termRows = 24;
 
     const msgHandler = (data) => {
         if (isShared && !SessionManager.get(sessionId)?.shareWritable) return;
@@ -20,6 +22,8 @@ const bindHandlers = (ws, conn, sessionId, config, isShared) => {
                 controlPlane.sendSessionResize(conn.sessionId, resize.width, resize.height);
                 SessionManager.recordResize(sessionId, resize.width, resize.height);
             }
+            termCols = resize.width;
+            termRows = resize.height;
             return;
         }
         SessionManager.setActiveWs(sessionId, ws);
@@ -29,7 +33,20 @@ const bindHandlers = (ws, conn, sessionId, config, isShared) => {
 
     const dataHandler = (data) => {
         if (scriptLayer?.suppressOutput) return;
-        ws.readyState === ws.OPEN && ws.send(data.toString());
+        let str = data.toString();
+
+        // PSReadLine sends \033[6n (DSR) to query the cursor position. Over WebSocket
+        // the round-trip delay causes the CPR response to arrive after PSReadLine has
+        // already timed out waiting for it. PSReadLine then treats the late \033[row;colR
+        // as an unknown key sequence, consuming the \033[ prefix and echoing the remainder
+        // ("56;13R") as literal text into the terminal. Intercept the query here and reply
+        // immediately so the response reaches PSReadLine before its timeout expires.
+        if (str.includes('\x1b[6n')) {
+            str = str.replaceAll('\x1b[6n', '');
+            dataSocket.write(`\x1b[${termRows};${termCols}R`);
+        }
+
+        if (str && ws.readyState === ws.OPEN) ws.send(str);
     };
     dataSocket.on("data", dataHandler);
 


### PR DESCRIPTION
PSReadLine sends \033[6n (Device Status Report) after each keypress to track cursorposition. The WebSocket round-trip delay causes the CPR response (\033[row;colR) toarrive after PSReadLine's timeout expires. At that point PSReadLine treats the late response as an unknown key sequence — it consumes the \033[ prefix and echoes the
remainder ("56;13R") as literal text, producing visible garbage on every keystroke in pwsh sessions. This does not affect bash/zsh or any other shell since PSReadLine
is specific to PowerShell.

**Root cause chain:**
1. PSReadLine sends `\033[6n` → PTY → engine → WebSocket → xterm.js
2. xterm.js responds with `\033[row;colR` via `onData` → WebSocket → engine → PTY
3. Round-trip latency exceeds PSReadLine's CPR timeout
4. Late `\033[56;13R` arrives when PSReadLine is no longer expecting it
5. PSReadLine parses `\033[` as an escape prefix, echoes `56;13R` as literal text

**Fix:** In `server/hooks/ssh.js`, the `dataHandler` now intercepts `\033[6n` in theSSH output stream before forwarding to the browser and immediately writes
`\033[rows;colsR` back to the engine socket using the last known terminal dimensions.PSReadLine gets an in-process response with no round-trip, never times out, and thegarbage text never appears. Terminal dimensions are tracked from resize messages
(defaults: 80×24).

## 📋 Description

When running PowerShell (pwsh) over SSH, every keystroke was appended with garbage
like `56;13R`, `56;20R`, etc. caused by PSReadLine's cursor position queries timing
out over the WebSocket connection. This fix intercepts those queries server-side and
responds immediately, eliminating the round-trip delay that caused the issue.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues

Fixes #1436
