### PR TITLE
fix(auth): encrypt secrets before bulk update in OIDC and LDAP contro…

### DIFF
--- a/server/controllers/ldap.js
+++ b/server/controllers/ldap.js
@@ -6,6 +6,7 @@ const Session = require("../models/Session");
 const { genSalt, hash } = require("bcrypt");
 const crypto = require("crypto");
 const logger = require("../utils/logger");
+const { encrypt } = require("../utils/encryption");
 
 const createLdapClient = (provider) => {
     const url = `${provider.useTLS ? "ldaps" : "ldap"}://${provider.host}:${provider.port}`;
@@ -53,6 +54,19 @@ module.exports.updateProvider = async (id, data) => {
             OIDCProvider.update({ enabled: false }, { where: { isInternal: true } }),
             LDAPProvider.update({ enabled: false }, { where: {} }),
         ]);
+    }
+
+    // LDAPProvider.update() is a bulk operation that bypasses the beforeUpdate
+    // instance hook, so bindPassword would be stored plain-text. Handle it here.
+    if (!data.bindPassword || data.bindPassword === "********") {
+        delete data.bindPassword;
+        delete data.bindPasswordIV;
+        delete data.bindPasswordAuthTag;
+    } else {
+        const { encrypted, iv, authTag } = encrypt(data.bindPassword);
+        data.bindPassword = encrypted;
+        data.bindPasswordIV = iv;
+        data.bindPasswordAuthTag = authTag;
     }
 
     await LDAPProvider.update(data, { where: { id } });

--- a/server/controllers/oidc.js
+++ b/server/controllers/oidc.js
@@ -7,6 +7,7 @@ const { genSalt, hash } = require("bcrypt");
 const crypto = require("crypto");
 const { Op } = require("sequelize");
 const logger = require("../utils/logger");
+const { encrypt } = require("../utils/encryption");
 
 const stateStore = new Map();
 
@@ -66,6 +67,19 @@ module.exports.updateProvider = async (providerId, data) => {
         if (data.enabled === true) {
             await LDAPProvider.update({ enabled: false }, { where: {} });
         }
+    }
+
+    // OIDCProvider.update() is a bulk operation that bypasses the beforeUpdate
+    // instance hook, so clientSecret would be stored plain-text. Handle it here.
+    if (!data.clientSecret || data.clientSecret === "********") {
+        delete data.clientSecret;
+        delete data.clientSecretIV;
+        delete data.clientSecretAuthTag;
+    } else {
+        const { encrypted, iv, authTag } = encrypt(data.clientSecret);
+        data.clientSecret = encrypted;
+        data.clientSecretIV = iv;
+        data.clientSecretAuthTag = authTag;
     }
 
     await OIDCProvider.update(data, { where: { id: providerId } });


### PR DESCRIPTION
## 📋 Description

When a provider's clientSecret (OIDC) or bindPassword (LDAP) is changed
after initial creation, the PATCH endpoint calls Sequelize's static
Model.update() — a bulk operation that bypasses per-instance beforeUpdate
hooks. The beforeUpdate hooks that handle AES-256-GCM encryption of the
secret therefore never fire. The new plain-text secret is written to the
column while the original clientSecretIV and clientSecretAuthTag from the
creation are left unchanged. On the next server start, afterFind calls
decrypt(plainTextSecret, originalIV, originalAuthTag) which fails GCM
authentication tag verification: "Unsupported state or unable to
authenticate data".

This manifests as OIDC/LDAP login being permanently broken after any
secret rotation. Providers whose secrets were never changed after
creation (e.g. Keycloak set up once) are unaffected; providers where
the secret was typed again (e.g. PocketID while troubleshooting) are
broken.

Fix: encrypt the secret manually in both updateProvider controllers
before the bulk update call. The "do not change" sentinel ("********")
and absent values are stripped from the payload so the existing
encrypted row is preserved.

Recovery for affected instances: open the provider in Settings →
Authentication, type in the correct client secret, and save. With this
fix deployed the secret will be stored correctly.

## 🚀 Changes made to ...
- [x] 🔧 Server

## 🔗 Related Issues
Fixes #1039
