### PR TITLE
docs: improve development setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ You can install Nexterm by clicking [here](https://docs.nexterm.dev/installation
 
 -   Node.js 18+
 -   Yarn
+-   FlatBuffers compiler (`flatc`)
 -   Docker (optional)
+
+Install FlatBuffers:
+
+| Platform | Command |
+|----------|---------|
+| macOS | `brew install flatbuffers` |
+| Ubuntu / Debian | `sudo apt install flatbuffers-compiler` |
+| Windows | `winget install Google.FlatBuffers` |
 
 ### Local Setup
 
@@ -62,6 +71,22 @@ git clone https://github.com/gnmyt/Nexterm.git
 cd Nexterm
 ```
 
+#### Configure environment
+
+Create a local environment file:
+
+```sh
+cp .env.example .env
+```
+
+Make sure `ENCRYPTION_KEY` is set in `.env`.
+
+You can generate a secure key using:
+
+| Platform | Command |
+|----------|---------|
+| macOS / Linux | `openssl rand -hex 32` |
+
 #### Install dependencies
 
 ```sh
@@ -70,10 +95,26 @@ cd client && yarn install
 cd ..
 ```
 
+#### Generate FlatBuffers schemas
+
+```sh
+yarn schema:generate
+```
+
+This step is required before starting the development server.
+
 #### Start development mode
 
 ```sh
 yarn dev
+```
+
+#### Start an engine
+
+The development server does not automatically start an engine. To connect to servers, an engine must be running separately:
+
+```sh
+yarn dev:engine
 ```
 
 ## 🔧 Configuration

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The development server does not automatically start an engine. To connect to ser
 yarn dev:engine
 ```
 
+If using local engine registration, set `LOCAL_ENGINE_TOKEN` in the server environment and use the same value as `REGISTRATION_TOKEN` for the engine.
+
 ## 🔧 Configuration
 
 ### Docker Images

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,58 +1,108 @@
 # Contributing to Nexterm
 
-You plan on contributing to Nexterm? That's great! This document will guide you through the process of contributing to
-the project.
+You plan on contributing to Nexterm? That's great! This document will guide you through the process of contributing to the project.
 
 ## 📦 Prerequisites
 
 - [Node.js](https://nodejs.org/en/download/) (v18 or higher)
 - [Yarn](https://yarnpkg.com/getting-started/install)
 - [Git](https://git-scm.com/downloads)
+- FlatBuffers compiler (`flatc`)
+
+### Installing FlatBuffers
+
+| Platform | Command |
+|-----------|----------|
+| macOS | `brew install flatbuffers` |
+| Ubuntu / Debian | `sudo apt install flatbuffers-compiler` |
+| Windows | `winget install Google.FlatBuffers` |
 
 ## 🛠️ Installation
 
 1. Clone the repository:
+
     ```sh
     git clone https://github.com/gnmyt/Nexterm.git
+    cd Nexterm
     ```
-2. Install the dependencies for the server:
+
+2. Create a local environment file:
+
+    ```sh
+    cp .env.example .env
+    ```
+
+3. Make sure `ENCRYPTION_KEY` is set in `.env`.
+
+    You can generate a secure key using:
+
+    | Platform | Command |
+    |-----------|----------|
+    | macOS / Linux | `openssl rand -hex 32` |
+   
+5. Install the dependencies for the server:
+
     ```sh
     yarn install
     ```
-3. Install the dependencies for the client:
+
+6. Install the dependencies for the client:
+
     ```sh
     cd client
     yarn install
+    cd ..
+    ```
+
+7. Generate FlatBuffers schemas:
+
+    ```sh
+    yarn schema:generate
     ```
 
 ## 🏃 Running the development server
 
-Starting the development server is as simple as running the following command:
+Start the development server:
 
 ```sh
 yarn dev
 ```
 
-This will start the server and the client in development mode. You can access the development server
-at [http://127.0.0.1:5173](http://127.0.0.1:5173).
+This will start the server and the client in development mode. You can access the development server at [http://127.0.0.1:5173](http://127.0.0.1:5173).
+
+### Starting an engine
+
+The development server does not automatically start an engine. To connect to servers, an engine must be running separately:
+
+```sh
+yarn dev:engine
+```
+
+If you want the engine to register automatically with the local control plane, set `LOCAL_ENGINE_TOKEN` in `.env` and use the same value as `REGISTRATION_TOKEN` for the engine.
 
 ## 🤝 Contributing
 
-1. **Fork the repository**: Click the "Fork" button at the top right of
-   the [repository page](https://github.com/gnmyt/Nexterm).
+1. **Fork the repository**: Click the "Fork" button at the top right of the [repository page](https://github.com/gnmyt/Nexterm).
 2. **Create a new branch**:
+
     ```sh
     git checkout -b feature/my-new-feature
     ```
+
 3. **Make your changes**: Implement your feature, fix, or improvement.
+
 4. **Commit your changes**:
+
     ```sh
     git commit -m "Add feature: my new feature"
     ```
+
 5. **Push to your fork**:
+
     ```sh
     git push origin feature/my-new-feature
     ```
+
 6. **Open a pull request**: Go to the original repository and create a PR with a clear description.
 
 ## 📝 Guidelines


### PR DESCRIPTION
## 📋 Description

This PR improves the development setup documentation in the README.

Previously, following the documented setup steps (`yarn install` + `yarn dev`) did not result in a working development environment on a fresh clone. Several required setup steps were undocumented, including environment configuration, FlatBuffers schema generation, and engine startup.

The README now documents:

- Creating a local `.env` file from `.env.example`
- Configuring `ENCRYPTION_KEY`
- Installing the FlatBuffers compiler (`flatc`)
- Generating FlatBuffers schemas via `yarn schema:generate`
- Starting an engine during development
- Using `LOCAL_ENGINE_TOKEN` for local engine registration
- Platform-specific notes for Linux, macOS, and Windows

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [x] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues

Fixes #1472
Fixes #1477