### PR TITLE
🐛 Use batch commands in monitoring

### DIFF
--- a/engine/src/core/session.c
+++ b/engine/src/core/session.c
@@ -114,19 +114,36 @@ static void session_cleanup_resources(nexterm_session_t* session) {
     }
 }
 
+static void session_remove_locked(nexterm_session_manager_t* sm,
+                                  nexterm_session_t* s) {
+    LOG_INFO("Session removed: %s", s->session_id);
+    session_cleanup_resources(s);
+    s->resize_pending = false;
+    s->session_id[0] = '\0';
+    sm->count--;
+}
+
 void nexterm_sm_remove(nexterm_session_manager_t* sm,
                        const char* session_id) {
     pthread_mutex_lock(&sm->mutex);
 
-    for (int i = 0; i < MAX_SESSIONS; i++) {
-        if (sm->sessions[i].session_id[0] != '\0' &&
-            strcmp(sm->sessions[i].session_id, session_id) == 0) {
-            LOG_INFO("Session removed: %s", session_id);
-            session_cleanup_resources(&sm->sessions[i]);
-            sm->sessions[i].session_id[0] = '\0';
-            sm->count--;
-            break;
-        }
+    nexterm_session_t* s = nexterm_sm_find_locked(sm, session_id);
+    if (s)
+        session_remove_locked(sm, s);
+
+    pthread_mutex_unlock(&sm->mutex);
+}
+
+void nexterm_sm_finish(nexterm_session_manager_t* sm,
+                       const char* session_id) {
+    pthread_mutex_lock(&sm->mutex);
+
+    nexterm_session_t* s = nexterm_sm_find_locked(sm, session_id);
+    if (s) {
+        s->guac_client = NULL;
+        s->state = SESSION_STATE_CLOSED;
+        s->thread_active = false;
+        session_remove_locked(sm, s);
     }
 
     pthread_mutex_unlock(&sm->mutex);

--- a/engine/src/core/session.h
+++ b/engine/src/core/session.h
@@ -90,6 +90,9 @@ nexterm_session_t* nexterm_sm_find_locked(nexterm_session_manager_t* sm,
 void nexterm_sm_remove(nexterm_session_manager_t* sm,
                        const char* session_id);
 
+void nexterm_sm_finish(nexterm_session_manager_t* sm,
+                       const char* session_id);
+
 void nexterm_sm_request_resize(nexterm_session_manager_t* sm,
                                const char* session_id,
                                uint16_t cols, uint16_t rows);

--- a/engine/src/net/connection.c
+++ b/engine/src/net/connection.c
@@ -287,9 +287,7 @@ static void* guac_session_thread(void* arg) {
     const char* protocol_name = session_type_to_protocol(session->type);
     if (!protocol_name) {
         LOG_ERROR("Unsupported session type for guac: %d", session->type);
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -299,9 +297,7 @@ static void* guac_session_thread(void* arg) {
 
     guac_client* client = guac_setup_client(session, cp, protocol_name);
     if (!client) {
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -321,21 +317,23 @@ static void* guac_session_thread(void* arg) {
     int user_thread_count = 0;
 
     pthread_t owner_thread;
-    if (start_user_thread(client, session->data_fd, 1, session->session_id, &owner_thread) != 0) {
+    int owner_fd = session->data_fd;
+    session->data_fd = -1;
+    if (start_user_thread(client, owner_fd, 1, session->session_id, &owner_thread) != 0) {
         LOG_ERROR("Failed to start owner user thread for session %s", session->session_id);
+        close(owner_fd);
+        nexterm_sm_lock(&g_session_manager);
+        nexterm_session_t* failed = nexterm_sm_find_locked(&g_session_manager, session->session_id);
+        if (failed) failed->guac_client = NULL;
+        nexterm_sm_unlock(&g_session_manager);
         guac_client_stop(client);
         guac_client_free(client);
-        session->guac_client = NULL;
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
         nexterm_cp_send_session_closed(cp, session->session_id, "internal error");
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
     user_threads[user_thread_count++] = owner_thread;
-
-    session->data_fd = -1;
 
     guac_accept_joins(session, client, user_threads, &user_thread_count,
                       (int)(sizeof(user_threads) / sizeof(user_threads[0])));
@@ -348,10 +346,13 @@ static void* guac_session_thread(void* arg) {
     snprintf(session_id, sizeof(session_id), "%s", session->session_id);
 
     LOG_INFO("Guac session %s ending", session_id);
+
+    nexterm_sm_lock(&g_session_manager);
+    nexterm_session_t* live = nexterm_sm_find_locked(&g_session_manager, session_id);
+    if (live) live->guac_client = NULL;
+    nexterm_sm_unlock(&g_session_manager);
+
     guac_client_stop(client);
-
-    session->guac_client = NULL;
-
     guac_client_free(client);
 
     char rec_path[512];
@@ -364,10 +365,8 @@ static void* guac_session_thread(void* arg) {
             unlink(rec_path);
     }
 
-    session->state = SESSION_STATE_CLOSED;
-    session->thread_active = false;
     nexterm_cp_send_session_closed(cp, session_id, "session ended");
-    nexterm_sm_remove(&g_session_manager, session_id);
+    nexterm_sm_finish(&g_session_manager, session_id);
 
     free(args);
     return NULL;

--- a/engine/src/net/sftp.c
+++ b/engine/src/net/sftp.c
@@ -1064,13 +1064,10 @@ cleanup:
     if (data_fd >= 0)
         close(data_fd);
 
-    session->state = SESSION_STATE_CLOSED;
-    session->thread_active = false;
-
     char sid[MAX_SESSION_ID_LEN];
     snprintf(sid, sizeof(sid), "%s", session->session_id);
     nexterm_cp_send_session_closed(cp, sid, "session ended");
-    nexterm_sm_remove(&g_session_manager, sid);
+    nexterm_sm_finish(&g_session_manager, sid);
 
     free(args);
     return NULL;

--- a/engine/src/net/ssh.c
+++ b/engine/src/net/ssh.c
@@ -108,10 +108,15 @@ static void ssh_drain_channel(LIBSSH2_CHANNEL* channel, int fd) {
 
 static void ssh_apply_pending_resize(nexterm_session_t* session,
                                      LIBSSH2_CHANNEL* channel) {
-    if (!session->resize_pending) return;
-    uint16_t cols = session->pending_cols;
-    uint16_t rows = session->pending_rows;
+    uint16_t cols, rows;
+    nexterm_sm_lock(&g_session_manager);
+    bool pending = session->resize_pending;
+    cols = session->pending_cols;
+    rows = session->pending_rows;
     session->resize_pending = false;
+    nexterm_sm_unlock(&g_session_manager);
+
+    if (!pending) return;
 
     int rc = libssh2_channel_request_pty_size(channel, cols, rows);
     if (rc && rc != LIBSSH2_ERROR_EAGAIN)
@@ -264,13 +269,10 @@ cleanup:
     if (data_fd >= 0)
         close(data_fd);
 
-    session->state = SESSION_STATE_CLOSED;
-    session->thread_active = false;
-
     char sid[MAX_SESSION_ID_LEN];
     snprintf(sid, sizeof(sid), "%s", session->session_id);
     nexterm_cp_send_session_closed(cp, sid, "session ended");
-    nexterm_sm_remove(&g_session_manager, sid);
+    nexterm_sm_finish(&g_session_manager, sid);
 
     free(args);
     return NULL;
@@ -321,13 +323,13 @@ static void* tunnel_session_thread(void* arg) {
 
     if (!username || username[0] == '\0') {
         nexterm_cp_send_session_result(cp, session->session_id, false, "Missing username", NULL);
-        session->state = SESSION_STATE_CLOSED;
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
     if (!remote_host || !remote_port_str) {
         nexterm_cp_send_session_result(cp, session->session_id, false, "Missing remoteHost/remotePort", NULL);
-        session->state = SESSION_STATE_CLOSED;
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -336,7 +338,7 @@ static void* tunnel_session_thread(void* arg) {
     long remote_port = strtol(remote_port_str, &endptr, 10);
     if (*endptr != '\0' || remote_port <= 0 || remote_port > 65535) {
         nexterm_cp_send_session_result(cp, session->session_id, false, "Invalid remotePort", NULL);
-        session->state = SESSION_STATE_CLOSED;
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -351,7 +353,7 @@ static void* tunnel_session_thread(void* arg) {
     if (data_fd < 0) {
         nexterm_cp_send_session_result(cp, session->session_id, false,
                                        "Failed to open data connection", NULL);
-        session->state = SESSION_STATE_CLOSED;
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -405,8 +407,10 @@ cleanup:
     if (data_fd >= 0)
         close(data_fd);
 
-    session->state = SESSION_STATE_CLOSED;
-    nexterm_cp_send_session_closed(cp, session->session_id, "tunnel ended");
+    char sid[MAX_SESSION_ID_LEN];
+    snprintf(sid, sizeof(sid), "%s", session->session_id);
+    nexterm_cp_send_session_closed(cp, sid, "tunnel ended");
+    nexterm_sm_finish(&g_session_manager, sid);
 
     free(args);
     return NULL;

--- a/engine/src/net/ssh.c
+++ b/engine/src/net/ssh.c
@@ -575,3 +575,211 @@ int nexterm_ssh_exec_command(nexterm_control_plane_t* cp,
     pthread_detach(thread);
     return 0;
 }
+
+typedef struct {
+    nexterm_control_plane_t* cp;
+    char request_id[128];
+    char host[256];
+    uint16_t port;
+    char* username;
+    char* password;
+    char* private_key;
+    char* passphrase;
+    char** ids;
+    char** commands;
+    int command_count;
+    jump_host_t jump_hosts[MAX_JUMP_HOSTS];
+    int jump_count;
+} exec_batch_args_t;
+
+static void exec_batch_free(exec_batch_args_t* args) {
+    free(args->username);
+    free(args->password);
+    free(args->private_key);
+    free(args->passphrase);
+    if (args->ids) {
+        for (int i = 0; i < args->command_count; i++) free(args->ids[i]);
+        free(args->ids);
+    }
+    if (args->commands) {
+        for (int i = 0; i < args->command_count; i++) free(args->commands[i]);
+        free(args->commands);
+    }
+    for (int i = 0; i < args->jump_count; i++) {
+        free(args->jump_hosts[i].password);
+        free(args->jump_hosts[i].private_key);
+        free(args->jump_hosts[i].passphrase);
+    }
+    free(args);
+}
+
+static void exec_batch_run_one(LIBSSH2_SESSION* ssh, const char* command,
+                               exec_batch_entry_t* entry,
+                               char** out_stdout, char** out_stderr) {
+    *out_stdout = NULL;
+    *out_stderr = NULL;
+    entry->success = false;
+    entry->exit_code = -1;
+
+    LIBSSH2_CHANNEL* channel = libssh2_channel_open_session(ssh);
+    if (!channel) {
+        entry->error_message = "Failed to open SSH channel";
+        return;
+    }
+
+    if (libssh2_channel_exec(channel, command) != 0) {
+        entry->error_message = "Failed to execute command";
+        libssh2_channel_free(channel);
+        return;
+    }
+
+    char* stdout_buf = malloc(SSH_EXEC_BUF_SIZE);
+    char* stderr_buf = malloc(SSH_EXEC_BUF_SIZE);
+    if (!stdout_buf || !stderr_buf) {
+        free(stdout_buf);
+        free(stderr_buf);
+        entry->error_message = "Out of memory";
+        libssh2_channel_free(channel);
+        return;
+    }
+
+    nexterm_ssh_read_stream(channel, stdout_buf, SSH_EXEC_BUF_SIZE, 0);
+    nexterm_ssh_read_stream(channel, stderr_buf, SSH_EXEC_BUF_SIZE, 1);
+
+    libssh2_channel_close(channel);
+    libssh2_channel_wait_closed(channel);
+    entry->exit_code = libssh2_channel_get_exit_status(channel);
+    libssh2_channel_free(channel);
+
+    *out_stdout = stdout_buf;
+    *out_stderr = stderr_buf;
+    entry->success = true;
+    entry->stdout_data = stdout_buf;
+    entry->stderr_data = stderr_buf;
+    entry->error_message = NULL;
+}
+
+static void* exec_batch_thread(void* arg) {
+    exec_batch_args_t* a = (exec_batch_args_t*)arg;
+    int ssh_sock = -1;
+    LIBSSH2_SESSION* ssh = NULL;
+    jump_chain_t jump_chain = {0};
+
+    if (nexterm_ssh_setup_with_jumphosts(a->host, a->port,
+            a->jump_hosts, a->jump_count, &ssh_sock, &ssh, &jump_chain) != 0) {
+        nexterm_cp_send_exec_batch_result(a->cp, a->request_id, false,
+                                          "Failed to connect to SSH host", NULL, 0);
+        exec_batch_free(a);
+        return NULL;
+    }
+
+    if (nexterm_ssh_auth(ssh, a->username, a->password,
+                         a->private_key, a->passphrase) != 0) {
+        nexterm_cp_send_exec_batch_result(a->cp, a->request_id, false,
+                                          "SSH authentication failed", NULL, 0);
+        nexterm_ssh_full_cleanup(ssh, NULL, ssh_sock, &jump_chain, "Auth failed");
+        exec_batch_free(a);
+        return NULL;
+    }
+
+    exec_batch_entry_t* entries = calloc(a->command_count, sizeof(exec_batch_entry_t));
+    char** outs = calloc(a->command_count, sizeof(char*));
+    char** errs = calloc(a->command_count, sizeof(char*));
+    if (!entries || !outs || !errs) {
+        free(entries);
+        free(outs);
+        free(errs);
+        nexterm_cp_send_exec_batch_result(a->cp, a->request_id, false,
+                                          "Out of memory", NULL, 0);
+        nexterm_ssh_full_cleanup(ssh, NULL, ssh_sock, &jump_chain, "OOM");
+        exec_batch_free(a);
+        return NULL;
+    }
+
+    for (int i = 0; i < a->command_count; i++) {
+        entries[i].id = a->ids[i];
+        exec_batch_run_one(ssh, a->commands[i], &entries[i], &outs[i], &errs[i]);
+    }
+
+    nexterm_cp_send_exec_batch_result(a->cp, a->request_id, true, NULL,
+                                      entries, (size_t)a->command_count);
+
+    for (int i = 0; i < a->command_count; i++) {
+        free(outs[i]);
+        free(errs[i]);
+    }
+    free(outs);
+    free(errs);
+    free(entries);
+
+    nexterm_ssh_full_cleanup(ssh, NULL, ssh_sock, &jump_chain, "Batch done");
+    exec_batch_free(a);
+    return NULL;
+}
+
+int nexterm_ssh_exec_batch(nexterm_control_plane_t* cp,
+                           const char* request_id,
+                           const char* host, uint16_t port,
+                           const ssh_credentials_t* creds,
+                           const char* const* ids,
+                           const char* const* commands,
+                           int command_count,
+                           const jump_host_t* jump_hosts,
+                           int jump_count) {
+    if (command_count <= 0) {
+        nexterm_cp_send_exec_batch_result(cp, request_id, false,
+                                          "No commands supplied", NULL, 0);
+        return -1;
+    }
+
+    exec_batch_args_t* args = calloc(1, sizeof(exec_batch_args_t));
+    if (!args) return -1;
+
+    args->cp = cp;
+    snprintf(args->request_id, sizeof(args->request_id), "%s", request_id);
+    snprintf(args->host, sizeof(args->host), "%s", host);
+    args->port = port;
+    args->username = strdup(creds->username ? creds->username : "");
+    args->password = strdup(creds->password ? creds->password : "");
+    args->private_key = strdup(creds->private_key ? creds->private_key : "");
+    args->passphrase = strdup(creds->passphrase ? creds->passphrase : "");
+
+    args->command_count = command_count;
+    args->ids = calloc(command_count, sizeof(char*));
+    args->commands = calloc(command_count, sizeof(char*));
+    if (!args->username || !args->password || !args->private_key ||
+        !args->passphrase || !args->ids || !args->commands) {
+        exec_batch_free(args);
+        nexterm_cp_send_exec_batch_result(cp, request_id, false, "Out of memory", NULL, 0);
+        return -1;
+    }
+
+    for (int i = 0; i < command_count; i++) {
+        args->ids[i] = strdup(ids[i] ? ids[i] : "");
+        args->commands[i] = strdup(commands[i] ? commands[i] : "");
+        if (!args->ids[i] || !args->commands[i]) {
+            exec_batch_free(args);
+            nexterm_cp_send_exec_batch_result(cp, request_id, false, "Out of memory", NULL, 0);
+            return -1;
+        }
+    }
+
+    args->jump_count = (jump_count > MAX_JUMP_HOSTS) ? MAX_JUMP_HOSTS : jump_count;
+    for (int i = 0; i < args->jump_count; i++) {
+        snprintf(args->jump_hosts[i].host, sizeof(args->jump_hosts[i].host), "%s", jump_hosts[i].host);
+        args->jump_hosts[i].port = jump_hosts[i].port;
+        snprintf(args->jump_hosts[i].username, sizeof(args->jump_hosts[i].username), "%s", jump_hosts[i].username);
+        args->jump_hosts[i].password = strdup(jump_hosts[i].password ? jump_hosts[i].password : "");
+        args->jump_hosts[i].private_key = strdup(jump_hosts[i].private_key ? jump_hosts[i].private_key : "");
+        args->jump_hosts[i].passphrase = strdup(jump_hosts[i].passphrase ? jump_hosts[i].passphrase : "");
+    }
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, exec_batch_thread, args) != 0) {
+        LOG_ERROR("Failed to create exec batch thread for %s", request_id);
+        exec_batch_free(args);
+        return -1;
+    }
+    pthread_detach(thread);
+    return 0;
+}

--- a/engine/src/net/ssh.h
+++ b/engine/src/net/ssh.h
@@ -30,6 +30,16 @@ int nexterm_ssh_exec_command(struct nexterm_control_plane* cp,
                              const jump_host_t* jump_hosts,
                              int jump_count);
 
+int nexterm_ssh_exec_batch(struct nexterm_control_plane* cp,
+                           const char* request_id,
+                           const char* host, uint16_t port,
+                           const ssh_credentials_t* creds,
+                           const char* const* ids,
+                           const char* const* commands,
+                           int command_count,
+                           const jump_host_t* jump_hosts,
+                           int jump_count);
+
 int nexterm_extract_jump_hosts(const nexterm_session_t* session,
                                jump_host_t* jump_hosts,
                                int max_jump_hosts);

--- a/engine/src/net/ssh_common.c
+++ b/engine/src/net/ssh_common.c
@@ -44,6 +44,7 @@ typedef struct {
     LIBSSH2_SESSION* parent_session;
     LIBSSH2_CHANNEL* channel;
     int sockfd;
+    int parent_sock;
 } channel_proxy_ctx_t;
 
 static void* channel_proxy_thread(void* arg) {
@@ -51,6 +52,7 @@ static void* channel_proxy_thread(void* arg) {
     LIBSSH2_SESSION* parent_session = ctx->parent_session;
     LIBSSH2_CHANNEL* channel = ctx->channel;
     int sockfd = ctx->sockfd;
+    int parent_sock = ctx->parent_sock;
     free(ctx);
 
     char buf[16384];
@@ -58,44 +60,65 @@ static void* channel_proxy_thread(void* arg) {
     libssh2_session_set_blocking(parent_session, 0);
 
     while (1) {
-        int had_activity = 0;
-
-        ssize_t n = libssh2_channel_read(channel, buf, sizeof(buf));
-        if (n > 0) {
-            ssize_t off = 0;
-            while (off < n) {
-                ssize_t w = write(sockfd, buf + off, (size_t)(n - off));
-                if (w <= 0) goto done;
-                off += w;
-            }
-            had_activity = 1;
-        } else if (n == 0 && libssh2_channel_eof(channel)) {
-            break;
-        } else if (n < 0 && n != LIBSSH2_ERROR_EAGAIN) {
-            break;
-        }
-
-        struct pollfd pfd = { .fd = sockfd, .events = POLLIN };
-        if (poll(&pfd, 1, had_activity ? 0 : 10) > 0) {
-            if (pfd.revents & POLLIN) {
-                ssize_t nr = read(sockfd, buf, sizeof(buf));
-                if (nr <= 0) break;
+        for (;;) {
+            ssize_t n = libssh2_channel_read(channel, buf, sizeof(buf));
+            if (n > 0) {
                 ssize_t off = 0;
-                while (off < nr) {
-                    ssize_t w = libssh2_channel_write(channel, buf + off, (size_t)(nr - off));
-                    if (w == LIBSSH2_ERROR_EAGAIN) {
-                        usleep(1000);
-                        continue;
-                    }
-                    if (w < 0) goto done;
+                while (off < n) {
+                    ssize_t w = write(sockfd, buf + off, (size_t)(n - off));
+                    if (w <= 0) goto done;
                     off += w;
                 }
-                had_activity = 1;
+                continue;
             }
-            if (pfd.revents & (POLLHUP | POLLERR)) break;
+            if (n == 0) {
+                if (libssh2_channel_eof(channel)) goto done;
+                break;
+            }
+            if (n == LIBSSH2_ERROR_EAGAIN) break;
+            goto done;
         }
 
-        if (!had_activity) usleep(1000);
+        struct pollfd fds[2] = {
+            { .fd = sockfd,      .events = POLLIN, .revents = 0 },
+            { .fd = parent_sock, .events = POLLIN, .revents = 0 },
+        };
+        int ret = poll(fds, 2, 1000);
+        if (ret < 0) {
+            if (errno == EINTR) continue;
+            goto done;
+        }
+
+        if (fds[0].revents & POLLIN) {
+            ssize_t nr = read(sockfd, buf, sizeof(buf));
+            if (nr <= 0) goto done;
+            ssize_t off = 0;
+            while (off < nr) {
+                ssize_t w = libssh2_channel_write(channel, buf + off, (size_t)(nr - off));
+                if (w == LIBSSH2_ERROR_EAGAIN) {
+                    struct pollfd wp = { .fd = parent_sock, .events = POLLOUT, .revents = 0 };
+                    poll(&wp, 1, 1000);
+                    continue;
+                }
+                if (w < 0) goto done;
+                off += w;
+            }
+        }
+
+        if (fds[0].revents & (POLLHUP | POLLERR)) goto done;
+        if (fds[1].revents & (POLLHUP | POLLERR)) {
+            for (;;) {
+                ssize_t n = libssh2_channel_read(channel, buf, sizeof(buf));
+                if (n <= 0) break;
+                ssize_t off = 0;
+                while (off < n) {
+                    ssize_t w = write(sockfd, buf + off, (size_t)(n - off));
+                    if (w <= 0) goto done;
+                    off += w;
+                }
+            }
+            goto done;
+        }
     }
 
 done:
@@ -105,6 +128,7 @@ done:
 }
 
 static int ssh_setup_on_channel(LIBSSH2_SESSION* parent_session,
+                                int parent_sock,
                                 LIBSSH2_CHANNEL* channel,
                                 LIBSSH2_SESSION** out_session,
                                 int* out_proxy_sock) {
@@ -123,6 +147,7 @@ static int ssh_setup_on_channel(LIBSSH2_SESSION* parent_session,
     ctx->parent_session = parent_session;
     ctx->channel = channel;
     ctx->sockfd = sv[1];
+    ctx->parent_sock = parent_sock;
 
     pthread_t tid;
     if (pthread_create(&tid, NULL, channel_proxy_thread, ctx) != 0) {
@@ -201,7 +226,7 @@ int nexterm_ssh_setup_with_jumphosts(const char* target_host, uint16_t target_po
         chain->channels[i - 1] = fwd;
 
         int proxy_sock = -1;
-        if (ssh_setup_on_channel(chain->sessions[i - 1], fwd,
+        if (ssh_setup_on_channel(chain->sessions[i - 1], chain->sockets[i - 1], fwd,
                                  &chain->sessions[i], &proxy_sock) != 0) {
             LOG_ERROR("Failed SSH handshake over tunnel to jump host %d", i + 1);
             nexterm_jump_chain_teardown(chain);
@@ -232,7 +257,7 @@ int nexterm_ssh_setup_with_jumphosts(const char* target_host, uint16_t target_po
     chain->channels[jump_count - 1] = target_fwd;
 
     int target_proxy_sock = -1;
-    if (ssh_setup_on_channel(chain->sessions[jump_count - 1], target_fwd,
+    if (ssh_setup_on_channel(chain->sessions[jump_count - 1], chain->sockets[jump_count - 1], target_fwd,
                              out_session, &target_proxy_sock) != 0) {
         LOG_ERROR("Failed SSH handshake to target over jump host chain");
         nexterm_jump_chain_teardown(chain);

--- a/engine/src/net/telnet.c
+++ b/engine/src/net/telnet.c
@@ -226,13 +226,10 @@ cleanup:
     if (data_fd >= 0)
         close(data_fd);
 
-    session->state = SESSION_STATE_CLOSED;
-    session->thread_active = false;
-
     char sid[MAX_SESSION_ID_LEN];
     snprintf(sid, sizeof(sid), "%s", session->session_id);
     nexterm_cp_send_session_closed(cp, sid, "session ended");
-    nexterm_sm_remove(&g_session_manager, sid);
+    nexterm_sm_finish(&g_session_manager, sid);
 
     free(args);
     return NULL;

--- a/engine/src/net/websocket.c
+++ b/engine/src/net/websocket.c
@@ -306,9 +306,7 @@ static void* websocket_session_thread(void* arg) {
         LOG_ERROR("WebSocket session %s: missing ws_url param", session->session_id);
         nexterm_cp_send_session_result(cp, session->session_id, false,
                                        "Missing ws_url parameter", NULL);
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -323,9 +321,7 @@ static void* websocket_session_thread(void* arg) {
         LOG_ERROR("WebSocket session %s: invalid URL: %s", session->session_id, url);
         nexterm_cp_send_session_result(cp, session->session_id, false,
                                        "Invalid WebSocket URL", NULL);
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -336,9 +332,7 @@ static void* websocket_session_thread(void* arg) {
     if (sock < 0) {
         nexterm_cp_send_session_result(cp, session->session_id, false,
                                        "Failed to connect to WebSocket server", NULL);
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -353,9 +347,7 @@ static void* websocket_session_thread(void* arg) {
             close(sock);
             nexterm_cp_send_session_result(cp, session->session_id, false,
                                            "TLS initialization failed", NULL);
-            session->state = SESSION_STATE_CLOSED;
-            session->thread_active = false;
-            nexterm_sm_remove(&g_session_manager, session->session_id);
+            nexterm_sm_finish(&g_session_manager, session->session_id);
             free(args);
             return NULL;
         }
@@ -374,9 +366,7 @@ static void* websocket_session_thread(void* arg) {
             close(sock);
             nexterm_cp_send_session_result(cp, session->session_id, false,
                                            "TLS handshake failed", NULL);
-            session->state = SESSION_STATE_CLOSED;
-            session->thread_active = false;
-            nexterm_sm_remove(&g_session_manager, session->session_id);
+            nexterm_sm_finish(&g_session_manager, session->session_id);
             free(args);
             return NULL;
         }
@@ -387,9 +377,7 @@ static void* websocket_session_thread(void* arg) {
         close(sock);
         nexterm_cp_send_session_result(cp, session->session_id, false,
                                        "WebSocket handshake failed", NULL);
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -400,9 +388,7 @@ static void* websocket_session_thread(void* arg) {
         close(sock);
         nexterm_cp_send_session_result(cp, session->session_id, false,
                                        "Failed to open data connection", NULL);
-        session->state = SESSION_STATE_CLOSED;
-        session->thread_active = false;
-        nexterm_sm_remove(&g_session_manager, session->session_id);
+        nexterm_sm_finish(&g_session_manager, session->session_id);
         free(args);
         return NULL;
     }
@@ -478,13 +464,10 @@ static void* websocket_session_thread(void* arg) {
     close(data_fd);
     session->data_fd = -1;
 
-    session->state = SESSION_STATE_CLOSED;
-    session->thread_active = false;
-
     char sid[MAX_SESSION_ID_LEN];
     snprintf(sid, sizeof(sid), "%s", session->session_id);
     nexterm_cp_send_session_closed(cp, sid, "websocket session ended");
-    nexterm_sm_remove(&g_session_manager, sid);
+    nexterm_sm_finish(&g_session_manager, sid);
 
     free(args);
     return NULL;

--- a/engine/src/proto/control_plane.c
+++ b/engine/src/proto/control_plane.c
@@ -751,19 +751,21 @@ void nexterm_cp_stop(nexterm_control_plane_t* cp) {
     LOG_INFO("Stopping control plane client");
     cp->running = false;
 
+    if (cp->sock_fd >= 0)
+        shutdown(cp->sock_fd, SHUT_RDWR);
+
+    pthread_join(cp->read_thread, NULL);
+    pthread_join(cp->keepalive_thread, NULL);
+
     if (cp->ssl) {
         nexterm_tls_cleanup(cp->ssl);
         cp->ssl = NULL;
     }
 
     if (cp->sock_fd >= 0) {
-        shutdown(cp->sock_fd, SHUT_RDWR);
         close(cp->sock_fd);
         cp->sock_fd = -1;
     }
-
-    pthread_join(cp->read_thread, NULL);
-    pthread_join(cp->keepalive_thread, NULL);
 }
 
 void nexterm_cp_destroy(nexterm_control_plane_t* cp) {

--- a/engine/src/proto/control_plane.c
+++ b/engine/src/proto/control_plane.c
@@ -362,6 +362,70 @@ static void handle_exec_command(nexterm_control_plane_t* cp,
                              jump_hosts, jump_count);
 }
 
+static void handle_exec_batch(nexterm_control_plane_t* cp,
+                              Nexterm_ControlPlane_Envelope_table_t envelope) {
+    Nexterm_ControlPlane_ExecBatch_table_t batch_msg =
+        Nexterm_ControlPlane_Envelope_exec_batch(envelope);
+    if (!batch_msg) {
+        LOG_WARN("Invalid ExecBatch message");
+        return;
+    }
+
+    const char* req_id = Nexterm_ControlPlane_ExecBatch_request_id(batch_msg);
+    const char* host = Nexterm_ControlPlane_ExecBatch_host(batch_msg);
+    uint16_t port = Nexterm_ControlPlane_ExecBatch_port(batch_msg);
+
+    if (!req_id || !host) {
+        LOG_WARN("ExecBatch: missing required fields");
+        return;
+    }
+
+    Nexterm_ControlPlane_ExecBatchCommand_vec_t cmds =
+        Nexterm_ControlPlane_ExecBatch_commands(batch_msg);
+    size_t count = cmds ? Nexterm_ControlPlane_ExecBatchCommand_vec_len(cmds) : 0;
+    if (count == 0) {
+        LOG_WARN("ExecBatch: no commands (req=%s)", req_id);
+        nexterm_cp_send_exec_batch_result(cp, req_id, false,
+                                          "No commands supplied", NULL, 0);
+        return;
+    }
+
+    const char** ids = calloc(count, sizeof(char*));
+    const char** commands = calloc(count, sizeof(char*));
+    if (!ids || !commands) {
+        free(ids);
+        free(commands);
+        nexterm_cp_send_exec_batch_result(cp, req_id, false, "Out of memory", NULL, 0);
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        Nexterm_ControlPlane_ExecBatchCommand_table_t c =
+            Nexterm_ControlPlane_ExecBatchCommand_vec_at(cmds, i);
+        ids[i] = Nexterm_ControlPlane_ExecBatchCommand_id(c);
+        commands[i] = Nexterm_ControlPlane_ExecBatchCommand_command(c);
+    }
+
+    ssh_credentials_t creds;
+    extract_ssh_credentials(Nexterm_ControlPlane_ExecBatch_params(batch_msg), &creds);
+    if (!creds.username) creds.username = "";
+
+    jump_host_t jump_hosts[MAX_JUMP_HOSTS];
+    int jump_count = 0;
+    extract_jump_hosts_from_msg(
+        Nexterm_ControlPlane_ExecBatch_jump_hosts(batch_msg),
+        jump_hosts, &jump_count);
+
+    LOG_INFO("ExecBatch: req=%s host=%s:%u commands=%zu (jump_hosts=%d)",
+             req_id, host, port, count, jump_count);
+
+    nexterm_ssh_exec_batch(cp, req_id, host, port, &creds,
+                           ids, commands, (int)count, jump_hosts, jump_count);
+
+    free(ids);
+    free(commands);
+}
+
 static bool check_port_open(const char* host, uint16_t port, uint32_t timeout_ms) {
     struct addrinfo hints = {0};
     hints.ai_family = AF_UNSPEC;
@@ -574,6 +638,9 @@ static void handle_message(nexterm_control_plane_t* cp, const uint8_t* buf) {
             break;
         case Nexterm_ControlPlane_MessageType_ExecCommand:
             handle_exec_command(cp, envelope);
+            break;
+        case Nexterm_ControlPlane_MessageType_ExecBatch:
+            handle_exec_batch(cp, envelope);
             break;
         case Nexterm_ControlPlane_MessageType_PortCheck:
             handle_port_check(cp, envelope);
@@ -923,6 +990,50 @@ int nexterm_cp_send_exec_result(nexterm_control_plane_t* cp,
         Nexterm_ControlPlane_ExecCommandResult_error_message_create_str(&builder, error_message);
 
     Nexterm_ControlPlane_Envelope_exec_command_result_end(&builder);
+    Nexterm_ControlPlane_Envelope_end_as_root(&builder);
+
+    return cp_send(cp, &builder);
+}
+
+int nexterm_cp_send_exec_batch_result(nexterm_control_plane_t* cp,
+                                      const char* request_id,
+                                      bool success,
+                                      const char* error_message,
+                                      const exec_batch_entry_t* entries,
+                                      size_t count) {
+    flatcc_builder_t builder;
+    flatcc_builder_init(&builder);
+
+    Nexterm_ControlPlane_Envelope_start_as_root(&builder);
+    Nexterm_ControlPlane_Envelope_msg_type_add(&builder,
+        Nexterm_ControlPlane_MessageType_ExecBatchResult);
+
+    Nexterm_ControlPlane_Envelope_exec_batch_result_start(&builder);
+    Nexterm_ControlPlane_ExecBatchResult_request_id_create_str(&builder, request_id);
+    Nexterm_ControlPlane_ExecBatchResult_success_add(&builder, success);
+    if (error_message)
+        Nexterm_ControlPlane_ExecBatchResult_error_message_create_str(&builder, error_message);
+
+    if (entries && count > 0) {
+        Nexterm_ControlPlane_ExecBatchResult_results_start(&builder);
+        for (size_t i = 0; i < count; i++) {
+            Nexterm_ControlPlane_ExecBatchResult_results_push_start(&builder);
+            Nexterm_ControlPlane_ExecBatchEntry_id_create_str(&builder,
+                entries[i].id ? entries[i].id : "");
+            Nexterm_ControlPlane_ExecBatchEntry_success_add(&builder, entries[i].success);
+            if (entries[i].stdout_data)
+                Nexterm_ControlPlane_ExecBatchEntry_stdout_data_create_str(&builder, entries[i].stdout_data);
+            if (entries[i].stderr_data)
+                Nexterm_ControlPlane_ExecBatchEntry_stderr_data_create_str(&builder, entries[i].stderr_data);
+            Nexterm_ControlPlane_ExecBatchEntry_exit_code_add(&builder, entries[i].exit_code);
+            if (entries[i].error_message)
+                Nexterm_ControlPlane_ExecBatchEntry_error_message_create_str(&builder, entries[i].error_message);
+            Nexterm_ControlPlane_ExecBatchResult_results_push_end(&builder);
+        }
+        Nexterm_ControlPlane_ExecBatchResult_results_end(&builder);
+    }
+
+    Nexterm_ControlPlane_Envelope_exec_batch_result_end(&builder);
     Nexterm_ControlPlane_Envelope_end_as_root(&builder);
 
     return cp_send(cp, &builder);

--- a/engine/src/proto/control_plane.h
+++ b/engine/src/proto/control_plane.h
@@ -72,6 +72,22 @@ int nexterm_cp_send_port_check_result(nexterm_control_plane_t* cp,
                                        const bool* online,
                                        size_t count);
 
+typedef struct {
+    const char* id;
+    bool success;
+    const char* stdout_data;
+    const char* stderr_data;
+    int32_t exit_code;
+    const char* error_message;
+} exec_batch_entry_t;
+
+int nexterm_cp_send_exec_batch_result(nexterm_control_plane_t* cp,
+                                      const char* request_id,
+                                      bool success,
+                                      const char* error_message,
+                                      const exec_batch_entry_t* entries,
+                                      size_t count);
+
 int nexterm_cp_upload_recording(nexterm_control_plane_t* cp,
                                 const char* session_id,
                                 const char* file_path);

--- a/schema/control_plane.fbs
+++ b/schema/control_plane.fbs
@@ -19,6 +19,8 @@ enum MessageType : byte {
 
     ExecCommand = 30,
     ExecCommandResult = 31,
+    ExecBatch = 32,
+    ExecBatchResult = 33,
 
     PortCheck = 40,
     PortCheckResult = 41,
@@ -134,6 +136,36 @@ table ExecCommandResult {
     error_message: string;
 }
 
+table ExecBatchCommand {
+    id: string;
+    command: string;
+}
+
+table ExecBatch {
+    request_id: string;
+    host: string;
+    port: uint16;
+    params: [ConnectionParam];
+    commands: [ExecBatchCommand];
+    jump_hosts: [JumpHost];
+}
+
+table ExecBatchEntry {
+    id: string;
+    success: bool;
+    stdout_data: string;
+    stderr_data: string;
+    exit_code: int32;
+    error_message: string;
+}
+
+table ExecBatchResult {
+    request_id: string;
+    success: bool;
+    error_message: string;
+    results: [ExecBatchEntry];
+}
+
 table ConnectionReady {
     session_id: string;
     connection_id: string;
@@ -220,6 +252,8 @@ table Envelope {
     connection_error: ConnectionError;
     exec_command: ExecCommand;
     exec_command_result: ExecCommandResult;
+    exec_batch: ExecBatch;
+    exec_batch_result: ExecBatchResult;
     port_check: PortCheck;
     port_check_result: PortCheckResult;
     http_fetch: HttpFetch;

--- a/server/lib/controlPlane/ControlPlaneServer.js
+++ b/server/lib/controlPlane/ControlPlaneServer.js
@@ -18,6 +18,7 @@ const {
     buildSessionJoin,
     buildSessionResize,
     buildExecCommand,
+    buildExecBatch,
     buildPortCheck,
     buildHttpFetch,
 } = require("./messageBuilders");
@@ -135,6 +136,19 @@ class ControlPlaneServer extends EventEmitter {
         const requestId = `exec-${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
         return this._createPendingRequest(requestId, null, () => {
             this._sendFrame(engine.socket, buildExecCommand(requestId, host, port, params, command, jumpHosts));
+        }, null, engine.engineId);
+    }
+
+    execCommandBatch(host, port, params, commands, jumpHosts = [], engineId = null) {
+        const engine = this._resolveEngine(engineId);
+        if (!engine) return Promise.reject(new Error("No engine connected"));
+        if (!Array.isArray(commands) || commands.length === 0) {
+            return Promise.resolve({ success: true, errorMessage: null, results: [] });
+        }
+
+        const requestId = `execbatch-${Date.now()}-${Math.random().toString(36).substring(2, 10)}`;
+        return this._createPendingRequest(requestId, null, () => {
+            this._sendFrame(engine.socket, buildExecBatch(requestId, host, port, params, commands, jumpHosts));
         }, null, engine.engineId);
     }
 
@@ -575,6 +589,32 @@ class ControlPlaneServer extends EventEmitter {
                     stderr: result.stderrData() || "",
                     exitCode: result.exitCode(),
                     errorMessage: result.errorMessage(),
+                }, respondingEngineId);
+                break;
+            }
+
+            case MessageType.ExecBatchResult: {
+                const result = envelope.execBatchResult();
+                if (!result) break;
+
+                const resultsLen = result.resultsLength();
+                const results = [];
+                for (let i = 0; i < resultsLen; i++) {
+                    const e = result.results(i);
+                    results.push({
+                        id: e.id(),
+                        success: e.success(),
+                        stdout: e.stdoutData() || "",
+                        stderr: e.stderrData() || "",
+                        exitCode: e.exitCode(),
+                        errorMessage: e.errorMessage(),
+                    });
+                }
+
+                this._resolvePending(result.requestId(), {
+                    success: result.success(),
+                    errorMessage: result.errorMessage(),
+                    results,
                 }, respondingEngineId);
                 break;
             }

--- a/server/lib/controlPlane/messageBuilders.js
+++ b/server/lib/controlPlane/messageBuilders.js
@@ -11,6 +11,8 @@ const {
     SessionResize,
     ConnectionParam,
     ExecCommand,
+    ExecBatch,
+    ExecBatchCommand,
     PortCheck,
     PortCheckTarget,
     JumpHost,
@@ -186,6 +188,39 @@ const buildExecCommand = (requestId, host, port, params, command, jumpHosts) => 
     return finishEnvelope(builder, Envelope.endEnvelope(builder));
 };
 
+const buildExecBatch = (requestId, host, port, params, commands, jumpHosts) => {
+    const builder = new flatbuffers.Builder(2048);
+    const reqIdOff = builder.createString(requestId);
+    const hostOff = builder.createString(host);
+
+    const cmdOffsets = commands.map(({ id, command }) => {
+        const idOff = builder.createString(String(id));
+        const cmdOff = builder.createString(String(command));
+        ExecBatchCommand.startExecBatchCommand(builder);
+        ExecBatchCommand.addId(builder, idOff);
+        ExecBatchCommand.addCommand(builder, cmdOff);
+        return ExecBatchCommand.endExecBatchCommand(builder);
+    });
+    const cmdsVecOff = ExecBatch.createCommandsVector(builder, cmdOffsets);
+
+    const paramsVecOff = buildConnectionParams(builder, params, ExecBatch);
+    const jumpHostsVecOff = buildJumpHostsVector(builder, jumpHosts, ExecBatch);
+
+    ExecBatch.startExecBatch(builder);
+    ExecBatch.addRequestId(builder, reqIdOff);
+    ExecBatch.addHost(builder, hostOff);
+    ExecBatch.addPort(builder, port);
+    if (paramsVecOff) ExecBatch.addParams(builder, paramsVecOff);
+    ExecBatch.addCommands(builder, cmdsVecOff);
+    if (jumpHostsVecOff) ExecBatch.addJumpHosts(builder, jumpHostsVecOff);
+    const batchOff = ExecBatch.endExecBatch(builder);
+
+    Envelope.startEnvelope(builder);
+    Envelope.addMsgType(builder, MessageType.ExecBatch);
+    Envelope.addExecBatch(builder, batchOff);
+    return finishEnvelope(builder, Envelope.endEnvelope(builder));
+};
+
 const buildPortCheck = (requestId, targets, timeoutMs) => {
     const builder = new flatbuffers.Builder(512);
     const reqIdOff = builder.createString(requestId);
@@ -256,6 +291,7 @@ module.exports = {
     buildSessionJoin,
     buildSessionResize,
     buildExecCommand,
+    buildExecBatch,
     buildPortCheck,
     buildHttpFetch,
 };

--- a/server/utils/monitoringService.js
+++ b/server/utils/monitoringService.js
@@ -20,9 +20,9 @@ const start = async () => {
 
     currentSettings = await getMonitoringSettingsInternal();
     const interval = currentSettings?.monitoringInterval ? currentSettings.monitoringInterval * 1000 : 60000;
-    
+
     logger.system("Starting monitoring service", { interval });
-    
+
     runMonitoring();
     monitoringInterval = setInterval(runMonitoring, interval);
 };
@@ -41,7 +41,7 @@ const runMonitoring = async () => {
             logger.verbose("Monitoring is disabled, skipping cycle");
             return;
         }
-        
+
         const entries = await Entry.findAll({ where: { type: "server" } });
         const toMonitor = entries.filter(e => e.config?.protocol === "ssh" && e.config?.monitoringEnabled);
         if (toMonitor.length) await Promise.allSettled(toMonitor.map(monitorEntry));
@@ -67,17 +67,31 @@ const monitorEntry = async (entry) => {
     }
 };
 
-const executeCommand = async (host, port, params, cmd, jumpHosts = []) => {
-    if (!controlPlane.hasEngine()) throw new Error("No engine connected");
+const IFACE_DETAIL_CMD =
+    'for d in /sys/class/net/*; do n=$(basename "$d"); ' +
+    'printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n" "$n" ' +
+    '"$(cat "$d/address" 2>/dev/null)" ' +
+    '"$(cat "$d/operstate" 2>/dev/null)" ' +
+    '"$(cat "$d/mtu" 2>/dev/null)" ' +
+    '"$(cat "$d/speed" 2>/dev/null)" ' +
+    '"$(cat "$d/statistics/rx_bytes" 2>/dev/null)" ' +
+    '"$(cat "$d/statistics/tx_bytes" 2>/dev/null)"; done';
 
-    const result = await controlPlane.execCommand(host, port, params, cmd, jumpHosts);
-    if (!result.success) {
-        throw new Error(result.errorMessage || "Command execution failed");
-    }
-    if (result.exitCode !== 0) {
-        throw new Error(`Command failed with exit code ${result.exitCode}`);
-    }
-    return (result.stdout || "").trim();
+const COMMANDS = {
+    cpu: "grep 'cpu ' /proc/stat",
+    memory: "free -b",
+    uptime: "cat /proc/uptime",
+    loadAverage: "cat /proc/loadavg",
+    processCount: "ps -e --no-headers | wc -l",
+    processList: "ps aux --sort=-%cpu | head -51",
+    lsblk: "lsblk -b -o NAME,TYPE,SIZE,MODEL,SERIAL,ROTA,MOUNTPOINT -J",
+    df: "df -B1 --output=source,fstype,size,used,avail,pcent,target | grep -E '^/dev'",
+    osRelease: "cat /etc/os-release",
+    kernel: "uname -r",
+    arch: "uname -m",
+    hostname: "hostname",
+    ipAddr: "ip -o addr show",
+    ifaceDetails: IFACE_DETAIL_CMD,
 };
 
 const collectServerData = async (entry, identity, credentials) => {
@@ -95,18 +109,31 @@ const collectServerData = async (entry, identity, credentials) => {
     const jumpHosts = await resolveJumpHosts(entry);
 
     try {
-        const execCmd = (cmd) => executeCommand(host, port, params, cmd, jumpHosts);
+        const commands = Object.entries(COMMANDS).map(([id, command]) => ({ id, command }));
+        const batch = await controlPlane.execCommandBatch(host, port, params, commands, jumpHosts);
+        if (!batch.success) {
+            throw new Error(batch.errorMessage || "Failed to connect to SSH host");
+        }
 
-        const [cpu, mem, uptime, load, processes] = await Promise.all([
-            getCPUUsage(execCmd), getMemoryUsage(execCmd), getUptime(execCmd), getLoadAverage(execCmd), getProcessCount(execCmd)
-        ]);
-        const [disk, os, network] = await Promise.all([getDiskUsage(execCmd), getOSInfo(execCmd), getNetworkInterfaces(execCmd)]);
-        const processList = await getProcessList(execCmd);
+        const out = {};
+        for (const r of batch.results || []) {
+            out[r.id] = r.success ? (r.stdout || "").trim() : "";
+        }
 
+        const memory = parseMemoryUsage(out.memory);
         return {
-            status: "online", timestamp: new Date(), cpuUsage: cpu,
-            memoryUsage: mem.usage, memoryTotal: mem.total, disk, uptime,
-            loadAverage: load, processes, processList, osInfo: os, network
+            status: "online",
+            timestamp: new Date(),
+            cpuUsage: parseCPUUsage(out.cpu),
+            memoryUsage: memory.usage,
+            memoryTotal: memory.total,
+            disk: parseDiskUsage(out.lsblk, out.df),
+            uptime: parseUptime(out.uptime),
+            loadAverage: parseLoadAverage(out.loadAverage),
+            processes: parseProcessCount(out.processCount),
+            processList: parseProcessList(out.processList),
+            osInfo: parseOSInfo(out.osRelease, out.kernel, out.arch, out.hostname),
+            network: parseNetworkInterfaces(out.ifaceDetails, out.ipAddr),
         };
     } catch (error) {
         logger.error("Error during monitoring data collection", { error: error.message, host });
@@ -114,30 +141,23 @@ const collectServerData = async (entry, identity, credentials) => {
     }
 };
 
-const getCPUUsage = async (execCmd) => {
+const parseCPUUsage = (output) => {
     try {
-        const output = await execCmd("grep 'cpu ' /proc/stat");
         const vals = output.split(" ").filter(Boolean).slice(1).map(Number);
         return Math.round(((vals.reduce((a, b) => a + b, 0) - vals[3]) / vals.reduce((a, b) => a + b, 0)) * 100);
     } catch { return null; }
 };
 
-const getMemoryUsage = async (execCmd) => {
+const parseMemoryUsage = (output) => {
     try {
-        const lines = (await execCmd("free -b")).split("\n");
-        const parts = lines[1].split(/\s+/);
+        const parts = output.split("\n")[1].split(/\s+/);
         const total = Number.parseInt(parts[1]), available = Number.parseInt(parts[6] || parts[3]);
         return { usage: Math.round(((total - available) / total) * 100), total };
     } catch { return { usage: null, total: null }; }
 };
 
-const getDiskUsage = async (execCmd) => {
+const parseDiskUsage = (lsblkOutput, dfOutput) => {
     try {
-        const [lsblkOutput, dfOutput] = await Promise.all([
-            execCmd("lsblk -b -o NAME,TYPE,SIZE,MODEL,SERIAL,ROTA,MOUNTPOINT -J").catch(() => ""),
-            execCmd("df -B1 --output=source,fstype,size,used,avail,pcent,target | grep -E '^/dev'").catch(() => ""),
-        ]);
-
         const usageMap = {};
         for (const line of dfOutput.split("\n").filter(Boolean)) {
             const p = line.trim().split(/\s+/);
@@ -218,24 +238,24 @@ const getDiskUsage = async (execCmd) => {
     } catch { return []; }
 };
 
-const getUptime = async (execCmd) => {
-    try { return Math.floor(Number.parseFloat((await execCmd("cat /proc/uptime")).split(" ")[0])); }
+const parseUptime = (output) => {
+    try { return Math.floor(Number.parseFloat(output.split(" ")[0])) || null; }
     catch { return null; }
 };
 
-const getLoadAverage = async (execCmd) => {
-    try { return (await execCmd("cat /proc/loadavg")).split(" ").slice(0, 3).map(parseFloat); }
+const parseLoadAverage = (output) => {
+    try { return output ? output.split(" ").slice(0, 3).map(parseFloat) : null; }
     catch { return null; }
 };
 
-const getProcessCount = async (execCmd) => {
-    try { return Number.parseInt(await execCmd("ps -e --no-headers | wc -l")); }
+const parseProcessCount = (output) => {
+    try { return Number.parseInt(output) || null; }
     catch { return null; }
 };
 
-const getProcessList = async (execCmd) => {
+const parseProcessList = (output) => {
     try {
-        return (await execCmd("ps aux --sort=-%cpu | head -51")).split("\n").slice(1, 51)
+        return output.split("\n").slice(1, 51)
             .filter(Boolean).map(line => {
                 const p = line.trim().split(/\s+/);
                 return p.length >= 11 ? {
@@ -247,15 +267,9 @@ const getProcessList = async (execCmd) => {
     } catch { return []; }
 };
 
-const getOSInfo = async (execCmd) => {
+const parseOSInfo = (osRelease, kernel, arch, hostname) => {
     try {
-        const [osRelease, kernel, arch, hostname] = await Promise.all([
-            execCmd("cat /etc/os-release").catch(() => ""),
-            execCmd("uname -r").catch(() => ""),
-            execCmd("uname -m").catch(() => ""),
-            execCmd("hostname").catch(() => ""),
-        ]);
-        const info = { kernel, architecture: arch, hostname: hostname.trim() };
+        const info = { kernel, architecture: arch, hostname };
         osRelease.split("\n").forEach(line => {
             if (line.startsWith("NAME=")) info.name = line.split("=")[1].replaceAll('"', "");
             if (line.startsWith("VERSION=")) info.version = line.split("=")[1].replaceAll('"', "");
@@ -264,56 +278,35 @@ const getOSInfo = async (execCmd) => {
     } catch { return {}; }
 };
 
-const getNetworkInterfaces = async (execCmd) => {
+const parseNetworkInterfaces = (ifaceDetails, ipOutput) => {
     try {
-        const [procNetDev, ipOutput] = await Promise.all([
-            execCmd("cat /proc/net/dev"),
-            execCmd("ip -o addr show").catch(() => ""),
-        ]);
-        
-        const trafficMap = {};
-        for (const line of procNetDev.split("\n").slice(2).filter(Boolean)) {
-            const match = line.match(/^\s*([^:]+):\s*(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)/);
-            if (match && match[1] !== "lo") {
-                trafficMap[match[1].trim()] = { rxBytes: Number.parseInt(match[2], 10) || 0, txBytes: Number.parseInt(match[3], 10) || 0 };
-            }
-        }
-        
         const ifaceMap = {};
+        for (const line of ifaceDetails.split("\n").filter(Boolean)) {
+            const [name, mac, state, mtu, speed, rxBytes, txBytes] = line.split("\t");
+            if (!name || name === "lo") continue;
+            ifaceMap[name] = {
+                name, ipv4: [], ipv6: [],
+                rxBytes: Number.parseInt(rxBytes, 10) || 0,
+                txBytes: Number.parseInt(txBytes, 10) || 0,
+                mac: mac?.trim() || null,
+                state: state?.trim() || null,
+                mtu: Number.parseInt(mtu, 10) || null,
+                speed: Number.parseInt(speed, 10) || null,
+            };
+        }
+
         for (const line of ipOutput.split("\n").filter(Boolean)) {
             const match = line.match(/^\d+:\s+(\S+)\s+inet6?\s+(\S+)/);
-            if (match) {
-                const name = match[1].replace(/@.*$/, "");
-                if (name === "lo") continue;
-                if (!ifaceMap[name]) ifaceMap[name] = { name, ipv4: [], ipv6: [], ...trafficMap[name] };
-                const addr = match[2];
-                if (addr.includes(":")) ifaceMap[name].ipv6.push(addr);
-                else ifaceMap[name].ipv4.push(addr);
-            }
+            if (!match) continue;
+            const name = match[1].replace(/@.*$/, "");
+            if (name === "lo") continue;
+            if (!ifaceMap[name]) ifaceMap[name] = { name, ipv4: [], ipv6: [], rxBytes: 0, txBytes: 0 };
+            const addr = match[2];
+            if (addr.includes(":")) ifaceMap[name].ipv6.push(addr);
+            else ifaceMap[name].ipv4.push(addr);
         }
-        
-        for (const name of Object.keys(trafficMap)) {
-            if (!ifaceMap[name]) ifaceMap[name] = { name, ipv4: [], ipv6: [], ...trafficMap[name] };
-        }
-        
-        const interfaces = Object.values(ifaceMap);
-        
-        await Promise.all(interfaces.map(async (iface) => {
-            try {
-                const [mac, state, mtu, speed] = await Promise.all([
-                    execCmd(`cat /sys/class/net/${iface.name}/address`).catch(() => ""),
-                    execCmd(`cat /sys/class/net/${iface.name}/operstate`).catch(() => ""),
-                    execCmd(`cat /sys/class/net/${iface.name}/mtu`).catch(() => ""),
-                    execCmd(`cat /sys/class/net/${iface.name}/speed`).catch(() => ""),
-                ]);
-                iface.mac = mac.trim() || null;
-                iface.state = state.trim() || null;
-                iface.mtu = Number.parseInt(mtu.trim(), 10) || null;
-                iface.speed = Number.parseInt(speed.trim(), 10) || null;
-            } catch {}
-        }));
-        
-        return interfaces;
+
+        return Object.values(ifaceMap);
     } catch (error) {
         logger.error("Error getting network interfaces", { error: error.message });
         return [];
@@ -354,7 +347,7 @@ const cleanupOldData = async () => {
         const settings = await getMonitoringSettingsInternal();
         const retentionHours = settings?.dataRetentionHours || 24;
         const retentionMs = retentionHours * 60 * 60 * 1000;
-        
+
         await MonitoringData.destroy({ where: { timestamp: { [Op.lt]: new Date(Date.now() - retentionMs) } } });
         logger.verbose("Cleaned up old monitoring data", { retentionHours });
     } catch (error) {


### PR DESCRIPTION
## 🐛 Use batch commands in monitoring

Nexterm used to make ~ 8 individual exec calls in order to retrieve all monitoring stats, per server. It also dynamically executed 4 commands per network interface. On a small host with 13 interfaces, it made 66 connections. Each of them made the key exchange and other operations which was really CPU-heavy.

This PR bundles exec calls into a single one to reduce connections and CPU lifecycles.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [x] 🔄 Other: Engine

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1479
