### PR TITLE
🐛 Restore card outline with dynamic colors

### DIFF
--- a/mobile/lib/utils/theme_manager.dart
+++ b/mobile/lib/utils/theme_manager.dart
@@ -97,18 +97,21 @@ class ThemeManager extends ChangeNotifier {
     },
   );
 
+  ColorScheme _buildScheme(ColorScheme? dynamicColorScheme, Brightness brightness) {
+    final seed = (_useDynamicColor && dynamicColorScheme != null)
+        ? dynamicColorScheme.primary
+        : _accentColor;
+    return ColorScheme.fromSeed(seedColor: seed, brightness: brightness);
+  }
+
   ThemeData lightTheme({ColorScheme? dynamicColorScheme}) => ThemeData(
-    colorScheme: (_useDynamicColor && dynamicColorScheme != null)
-        ? dynamicColorScheme
-        : ColorScheme.fromSeed(seedColor: _accentColor),
+    colorScheme: _buildScheme(dynamicColorScheme, Brightness.light),
     useMaterial3: true,
     pageTransitionsTheme: _pageTransitions,
   );
 
   ThemeData darkTheme({ColorScheme? dynamicColorScheme}) => ThemeData(
-    colorScheme: (_useDynamicColor && dynamicColorScheme != null)
-        ? dynamicColorScheme
-        : ColorScheme.fromSeed(seedColor: _accentColor, brightness: Brightness.dark),
+    colorScheme: _buildScheme(dynamicColorScheme, Brightness.dark),
     useMaterial3: true,
     pageTransitionsTheme: _pageTransitions,
   );


### PR DESCRIPTION
## 🐛 Restore card outline with dynamic colors

Since the dynamic colors update, the app no longer shows outlines inside of the mobile app. This PR fixes it by building a custom scheme with the base colors.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [x] 🔄 Other: Mobile

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1431