### PR TITLE
Bug: local engine crash handling and cpu usage

### DIFF
--- a/engine/src/main.c
+++ b/engine/src/main.c
@@ -5,25 +5,24 @@
 
 #include <libssh2.h>
 
-#ifdef __linux__
-#if defined(__has_include)
-#if __has_include(<execinfo.h>)
-#define NEXTERM_HAVE_EXECINFO 1
-#include <execinfo.h>
-#endif
-#else
-#define NEXTERM_HAVE_EXECINFO 1
-#include <execinfo.h>
-#endif
-#endif
-
 #include <getopt.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+
+#if defined(__has_include)
+#if __has_include(<execinfo.h>)
+#define NEXTERM_HAVE_EXECINFO 1
+#include <execinfo.h>
+#endif
+#elif defined(__GLIBC__)
+#define NEXTERM_HAVE_EXECINFO 1
+#include <execinfo.h>
+#endif
 
 nexterm_session_manager_t g_session_manager;
 
@@ -38,15 +37,55 @@ static void signal_handler(int sig) {
     }
 }
 
-static void crash_signal_handler(int sig) {
+static void crash_write(const char* s) {
+    size_t n = 0;
+    while (s[n]) n++;
+    ssize_t r = write(STDERR_FILENO, s, n);
+    (void)r;
+}
+
+static void crash_write_hex(uintptr_t v) {
+    static const char hex[] = "0123456789abcdef";
+    char buf[2 + sizeof(uintptr_t) * 2];
+    int i = (int)sizeof(buf);
+    if (v == 0) {
+        buf[--i] = '0';
+    } else {
+        while (v && i > 2) {
+            buf[--i] = hex[v & 0xf];
+            v >>= 4;
+        }
+    }
+    buf[--i] = 'x';
+    buf[--i] = '0';
+    ssize_t r = write(STDERR_FILENO, &buf[i], sizeof(buf) - (size_t)i);
+    (void)r;
+}
+
+static void crash_signal_handler(int sig, siginfo_t* info, void* ucontext) {
+    (void)ucontext;
+
+    crash_write("\n[nexterm-crash] Fatal signal ");
+    switch (sig) {
+        case SIGSEGV: crash_write("SIGSEGV"); break;
+        case SIGABRT: crash_write("SIGABRT"); break;
+        case SIGBUS:  crash_write("SIGBUS");  break;
+        default:      crash_write("signal");  break;
+    }
+    if ((sig == SIGSEGV || sig == SIGBUS) && info) {
+        crash_write(" fault_addr=");
+        crash_write_hex((uintptr_t)info->si_addr);
+    }
+    crash_write("\n");
+
 #ifdef NEXTERM_HAVE_EXECINFO
     void* frames[64];
     int frame_count = backtrace(frames, 64);
-    static const char prefix[] = "\n[nexterm-crash] Fatal signal received. Backtrace follows:\n";
-    write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
+    crash_write("[nexterm-crash] Backtrace:\n");
     backtrace_symbols_fd(frames, frame_count, STDERR_FILENO);
 #else
-    (void)sig;
+    crash_write("[nexterm-crash] No in-process backtrace (no execinfo); "
+                "inspect the core dump under data/logs/crashes.\n");
 #endif
 
     signal(sig, SIG_DFL);
@@ -136,9 +175,10 @@ int main(int argc, char* argv[]) {
     sigaction(SIGTERM, &sa, NULL);
 
     struct sigaction crash_sa;
-    crash_sa.sa_handler = crash_signal_handler;
+    memset(&crash_sa, 0, sizeof(crash_sa));
+    crash_sa.sa_sigaction = crash_signal_handler;
     sigemptyset(&crash_sa.sa_mask);
-    crash_sa.sa_flags = SA_RESETHAND;
+    crash_sa.sa_flags = SA_RESETHAND | SA_SIGINFO;
     sigaction(SIGSEGV, &crash_sa, NULL);
     sigaction(SIGABRT, &crash_sa, NULL);
     sigaction(SIGBUS, &crash_sa, NULL);
@@ -149,7 +189,9 @@ int main(int argc, char* argv[]) {
 
     nexterm_control_plane_t* cp = nexterm_cp_create(server_host, server_port,
                                                      config.registration_token,
-                                                     config.tls);
+                                                     config.tls,
+                                                     config.ca_cert_path,
+                                                     config.tls_skip_verify);
     if (!cp) {
         LOG_ERROR("Failed to create control plane client");
         return 1;

--- a/engine/src/main.c
+++ b/engine/src/main.c
@@ -5,18 +5,25 @@
 
 #include <libssh2.h>
 
+#ifdef __linux__
+#if defined(__has_include)
+#if __has_include(<execinfo.h>)
+#define NEXTERM_HAVE_EXECINFO 1
+#include <execinfo.h>
+#endif
+#else
+#define NEXTERM_HAVE_EXECINFO 1
+#include <execinfo.h>
+#endif
+#endif
+
 #include <getopt.h>
 #include <signal.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-
-#ifdef __GLIBC__
-#include <execinfo.h>
-#endif
 
 nexterm_session_manager_t g_session_manager;
 
@@ -31,55 +38,15 @@ static void signal_handler(int sig) {
     }
 }
 
-static void crash_write(const char* s) {
-    size_t n = 0;
-    while (s[n]) n++;
-    ssize_t r = write(STDERR_FILENO, s, n);
-    (void)r;
-}
-
-static void crash_write_hex(uintptr_t v) {
-    static const char hex[] = "0123456789abcdef";
-    char buf[2 + sizeof(uintptr_t) * 2];
-    int i = (int)sizeof(buf);
-    if (v == 0) {
-        buf[--i] = '0';
-    } else {
-        while (v && i > 2) {
-            buf[--i] = hex[v & 0xf];
-            v >>= 4;
-        }
-    }
-    buf[--i] = 'x';
-    buf[--i] = '0';
-    ssize_t r = write(STDERR_FILENO, &buf[i], sizeof(buf) - (size_t)i);
-    (void)r;
-}
-
-static void crash_signal_handler(int sig, siginfo_t* info, void* ucontext) {
-    (void)ucontext;
-
-    crash_write("\n[nexterm-crash] Fatal signal ");
-    switch (sig) {
-        case SIGSEGV: crash_write("SIGSEGV"); break;
-        case SIGABRT: crash_write("SIGABRT"); break;
-        case SIGBUS:  crash_write("SIGBUS");  break;
-        default:      crash_write("signal");  break;
-    }
-    if ((sig == SIGSEGV || sig == SIGBUS) && info) {
-        crash_write(" fault_addr=");
-        crash_write_hex((uintptr_t)info->si_addr);
-    }
-    crash_write("\n");
-
-#ifdef __GLIBC__
+static void crash_signal_handler(int sig) {
+#ifdef NEXTERM_HAVE_EXECINFO
     void* frames[64];
     int frame_count = backtrace(frames, 64);
-    crash_write("[nexterm-crash] Backtrace:\n");
+    static const char prefix[] = "\n[nexterm-crash] Fatal signal received. Backtrace follows:\n";
+    write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
     backtrace_symbols_fd(frames, frame_count, STDERR_FILENO);
 #else
-    crash_write("[nexterm-crash] No in-process backtrace (musl build); "
-                "inspect the core dump under data/logs/crashes.\n");
+    (void)sig;
 #endif
 
     signal(sig, SIG_DFL);
@@ -169,10 +136,9 @@ int main(int argc, char* argv[]) {
     sigaction(SIGTERM, &sa, NULL);
 
     struct sigaction crash_sa;
-    memset(&crash_sa, 0, sizeof(crash_sa));
-    crash_sa.sa_sigaction = crash_signal_handler;
+    crash_sa.sa_handler = crash_signal_handler;
     sigemptyset(&crash_sa.sa_mask);
-    crash_sa.sa_flags = SA_RESETHAND | SA_SIGINFO;
+    crash_sa.sa_flags = SA_RESETHAND;
     sigaction(SIGSEGV, &crash_sa, NULL);
     sigaction(SIGABRT, &crash_sa, NULL);
     sigaction(SIGBUS, &crash_sa, NULL);
@@ -183,9 +149,7 @@ int main(int argc, char* argv[]) {
 
     nexterm_control_plane_t* cp = nexterm_cp_create(server_host, server_port,
                                                      config.registration_token,
-                                                     config.tls,
-                                                     config.ca_cert_path,
-                                                     config.tls_skip_verify);
+                                                     config.tls);
     if (!cp) {
         LOG_ERROR("Failed to create control plane client");
         return 1;

--- a/vendor/guacamole-server/src/protocols/rdp/rdp.c
+++ b/vendor/guacamole-server/src/protocols/rdp/rdp.c
@@ -77,6 +77,9 @@
 #include <stdlib.h>
 #include <time.h>
 
+#define GUAC_RDP_EVENT_DRAIN_LIMIT 64
+#define GUAC_RDP_EVENT_DRAIN_BACKOFF 1
+
 /**
  * Initializes and loads the necessary FreeRDP plugins based on the current
  * RDP session settings. This function is designed to work in environments
@@ -618,13 +621,18 @@ static int guac_rdp_handle_connection(guac_client* client) {
         if (wait_result < 0)
             break;
 
-        int connection_closing;
+        int connection_closing = 0;
+        int drained_events = 0;
         do {
 
             /* Handle any queued FreeRDP events (this may result in RDP messages
              * being sent), aborting later if FreeRDP event handling fails */
-            if (!guac_rdp_handle_events(rdp_client))
+            if (!guac_rdp_handle_events(rdp_client)) {
                 wait_result = -1;
+                break;
+            }
+
+            drained_events++;
 
             /* Test whether the RDP server is closing the connection */
 #ifdef HAVE_DISCONNECT_CONTEXT
@@ -634,7 +642,11 @@ static int guac_rdp_handle_connection(guac_client* client) {
 #endif
 
         } while (!connection_closing &&
+                drained_events < GUAC_RDP_EVENT_DRAIN_LIMIT &&
                 (wait_result = rdp_guac_client_wait_for_events(client, 0)) > 0);
+
+        if (!connection_closing && wait_result > 0)
+            guac_timestamp_msleep(GUAC_RDP_EVENT_DRAIN_BACKOFF);
 
         /* Notify display of any changes to the GDI that may have occurred
          * while handling events/messages */


### PR DESCRIPTION
## 📋 Description

Fixes two bugs related to the engine:
1. Upon engine crash, the supervisor was not accurately detecting and restarting the engine.
2. Fixed a high-CPU spin in the vendored Guacamole RDP event loop.
   The RDP message handler drains immediately available FreeRDP/WinPR events using a zero-timeout wait. If one of those event handles remains signaled, the loop can spin indefinitely and peg a CPU core. This change caps consecutive zero-timeout drain iterations and adds a small backoff before returning to the normal blocking wait, preventing the engine from burning CPU while still allowing queued RDP events to be processed promptly.

   Also fixed the event-handling failure path so freerdp_check_event_handles() failures are preserved instead of being overwritten by the next zero-timeout wait result.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->
