### PR TITLE
Use correct terminal font in shared sessions

### DIFF
--- a/client/src/pages/Servers/components/ViewContainer/renderer/XtermRenderer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/XtermRenderer.jsx
@@ -34,6 +34,9 @@ const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getS
     const userContext = useContext(UserContext);
     const sessionToken = userContext?.sessionToken;
     const { theme, getCurrentTheme, selectedFont, fontSize, cursorStyle, cursorBlink, selectedTheme } = usePreferences();
+
+    const effectiveFont = (isShared && session.fontFamily) ? session.fontFamily : selectedFont;
+    const effectiveFontSize = (isShared && session.fontSize) ? session.fontSize : fontSize;
     const aiContext = useContext(AIContext);
     const isAIAvailable = aiContext?.isAIAvailable || (() => false);
     const aiAvailableRef = useRef(false);
@@ -181,8 +184,8 @@ const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getS
         const term = new Xterm({
             cursorBlink: cursorBlink,
             cursorStyle: cursorStyle,
-            fontSize: fontSize,
-            fontFamily: selectedFont,
+            fontSize: effectiveFontSize,
+            fontFamily: effectiveFont,
             theme: {
                 background: (theme === "light" && isLightTerminalTheme) ? "#F3F3F3" : terminalTheme.background,
                 foreground: (theme === "light" && isLightTerminalTheme) ? "#000000" : terminalTheme.foreground,
@@ -419,7 +422,7 @@ const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getS
             termRef.current = null;
             wsRef.current = null;
         };
-    }, [sessionToken, selectedFont, fontSize, cursorStyle, cursorBlink, selectedTheme, isShared]);
+    }, [sessionToken, effectiveFont, effectiveFontSize, cursorStyle, cursorBlink, selectedTheme, isShared]);
 
     return (
         <div className="xterm-container" onContextMenu={!isShared ? handleContextMenu : undefined}>

--- a/server/routes/share.js
+++ b/server/routes/share.js
@@ -2,6 +2,7 @@ const { Router } = require("express");
 const SessionManager = require("../lib/SessionManager");
 const Entry = require("../models/Entry");
 const Organization = require("../models/Organization");
+const Account = require("../models/Account");
 
 const app = Router();
 
@@ -28,6 +29,9 @@ app.get("/:shareId", async (req, res) => {
         ? (await Organization.findByPk(entry.organizationId, { attributes: ["name"] }))?.name
         : null;
 
+    const owner = await Account.findByPk(session.accountId, { attributes: ["preferences"] });
+    const ownerTerminal = owner?.preferences?.terminal || {};
+
     res.json({
         id: session.sessionId,
         server: {
@@ -42,6 +46,8 @@ app.get("/:shareId", async (req, res) => {
         type: session.configuration.type || undefined,
         organizationId: entry.organizationId || null,
         organizationName: orgName,
+        fontFamily: ownerTerminal.fontFamily || undefined,
+        fontSize: ownerTerminal.fontSize || undefined,
     });
 });
 


### PR DESCRIPTION
## Use correct terminal font in shared sessions

This PR adds support for custom terminal font settings in shared sessions. Whenever a user now shares a session, its font settings will be shared with the remote user that connects to it.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #1420