### PR TITLE
Add New File / New Folder / Refresh Button in SFTP

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1779,7 +1779,9 @@
         "clearTerminal": "Clear Terminal",
         "properties": "Properties",
         "openTerminal": "Open Terminal Here",
-        "downloadFolder": "Download Folder"
+        "downloadFolder": "Download Folder",
+        "newFile": "New File",
+        "newFolder": "New Folder"
       },
       "properties": {
         "general": "General",
@@ -1841,7 +1843,8 @@
         "switchToGrid": "Switch to grid view",
         "switchToList": "Switch to list view",
         "search": "Search files",
-        "closeSearch": "Close search"
+        "closeSearch": "Close search",
+        "refresh": "Refresh"
       },
       "item": {
         "link": "link"

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/FileRenderer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/FileRenderer.jsx
@@ -122,7 +122,7 @@ export const FileRenderer = ({ session, disconnectFromServer, setOpenFileEditors
 
             setIsUploading(false);
             setUploadProgress(0);
-            listFiles();
+            listFiles(true);
             sendToast(t("common.success"), t("servers.fileManager.toast.uploaded", { name: file.name }));
             return true;
         } catch (err) {
@@ -191,7 +191,7 @@ export const FileRenderer = ({ session, disconnectFromServer, setOpenFileEditors
                 case OPERATIONS.MOVE_FILES:
                 case OPERATIONS.COPY_FILES:
                 case OPERATIONS.CHMOD:
-                    listFiles();
+                    listFiles(true);
                     break;
                 case OPERATIONS.ERROR:
                     sendToast(t("common.error"), payload?.message || t("servers.fileManager.toast.error"));
@@ -260,7 +260,7 @@ export const FileRenderer = ({ session, disconnectFromServer, setOpenFileEditors
 
     const createFile = (fileName) => sendOperation(OPERATIONS.CREATE_FILE, { path: `${directory}/${fileName}` });
     const createFolder = (folderName) => sendOperation(OPERATIONS.CREATE_FOLDER, { path: `${directory}/${folderName}` });
-    const listFiles = useCallback(() => { setLoading(true); setError(null); sendOperation(OPERATIONS.LIST_FILES, { path: directory }); }, [directory, sendOperation]);
+    const listFiles = useCallback((silent = false) => { if (!silent) setLoading(true); setError(null); sendOperation(OPERATIONS.LIST_FILES, { path: directory }); }, [directory, sendOperation]);
     const moveFiles = useCallback((sources, destination) => sendOperation(OPERATIONS.MOVE_FILES, { sources, destination }), [sendOperation]);
     const copyFiles = useCallback((sources, destination) => sendOperation(OPERATIONS.COPY_FILES, { sources, destination }), [sendOperation]);
 
@@ -330,7 +330,7 @@ export const FileRenderer = ({ session, disconnectFromServer, setOpenFileEditors
             </div>
             <div className="file-manager">
                 <ActionBar path={directory} updatePath={changeDirectory} createFile={() => fileListRef.current?.startCreateFile()}
-                    createFolder={() => fileListRef.current?.startCreateFolder()} uploadFile={uploadFile} goBack={goBack} goForward={goForward} historyIndex={historyIndex}
+                    createFolder={() => fileListRef.current?.startCreateFolder()} uploadFile={uploadFile} refreshFiles={() => listFiles(true)} goBack={goBack} goForward={goForward} historyIndex={historyIndex}
                     historyLength={history.length} viewMode={viewMode} setViewMode={setViewMode} 
                     searchDirectories={searchDirectories} directorySuggestions={directorySuggestions} 
                     setDirectorySuggestions={setDirectorySuggestions} moveFiles={moveFiles} copyFiles={copyFiles}

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/ActionBar/ActionBar.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/ActionBar/ActionBar.jsx
@@ -13,6 +13,7 @@ import {
     mdiContentCopy,
     mdiMagnify,
     mdiClose,
+    mdiRefresh,
 } from "@mdi/js";
 import { Fragment, useState, useRef, useEffect, useCallback } from "react";
 import { ContextMenu, ContextMenuItem, useContextMenu } from "@/common/components/ContextMenu";
@@ -25,6 +26,7 @@ export const ActionBar = ({
                               createFile,
                               createFolder,
                               uploadFile,
+                              refreshFiles,
                               goBack,
                               goForward,
                               historyIndex,
@@ -72,7 +74,8 @@ export const ActionBar = ({
 
     const navigate = (displayIndex, isTruncated = false, originalIndex = null) => {
         const pathArray = getPathArray();
-        updatePath(`/${pathArray.slice(0, (isTruncated ? originalIndex : displayIndex) + 1).join("/")}`);
+        const target = `/${pathArray.slice(0, (isTruncated ? originalIndex : displayIndex) + 1).join("/")}`;
+        target === path ? refreshFiles?.() : updatePath(target);
     };
 
     const getTruncatedPathArray = () => {
@@ -284,7 +287,7 @@ export const ActionBar = ({
             <>
                 <div 
                     className={`path-part-divider root-drop ${dropTarget === "/" ? "drop-target" : ""}`}
-                    onClick={(e) => { e.stopPropagation(); updatePath("/"); }}
+                    onClick={(e) => { e.stopPropagation(); path === "/" ? refreshFiles?.() : updatePath("/"); }}
                     onDragOver={(e) => handlePathDragOver(e, "/")}
                     onDragLeave={handlePathDragLeave}
                     onDrop={(e) => handlePathDrop(e, "/")}
@@ -379,6 +382,7 @@ export const ActionBar = ({
                 <Icon path={viewMode === "list" ? mdiViewGrid : mdiViewList}
                       onClick={() => setViewMode(viewMode === "list" ? "grid" : "list")}
                       title={viewMode === "list" ? t("servers.fileManager.actionBar.switchToGrid") : t("servers.fileManager.actionBar.switchToList")} />
+                <Icon path={mdiRefresh} onClick={refreshFiles} title={t("servers.fileManager.actionBar.refresh")} />
                 <Icon path={mdiFileUpload} onClick={uploadFile} />
                 <Icon path={mdiFilePlus} onClick={createFile} />
                 <Icon path={mdiFolderPlus} onClick={createFolder} />

--- a/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/FileList/FileList.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/FileRenderer/components/FileList/FileList.jsx
@@ -4,9 +4,9 @@ import Icon from "@mdi/react";
 import {
     mdiFile, mdiFolder, mdiAlertCircle, mdiFormTextbox, mdiTextBoxEdit,
     mdiFileDownload, mdiTrashCan, mdiEye, mdiFileMove, mdiContentCopy,
-    mdiInformationOutline, mdiConsole, mdiFileSearchOutline,
+    mdiInformationOutline, mdiConsole, mdiFileSearchOutline, mdiFilePlus, mdiFolderPlus,
 } from "@mdi/js";
-import { ContextMenu, ContextMenuItem, useContextMenu } from "@/common/components/ContextMenu";
+import { ContextMenu, ContextMenuItem, ContextMenuSeparator, useContextMenu } from "@/common/components/ContextMenu";
 import { ActionConfirmDialog } from "@/common/components/ActionConfirmDialog/ActionConfirmDialog.jsx";
 import { useTranslation } from "react-i18next";
 import { usePreferences } from "@/common/contexts/PreferencesContext.jsx";
@@ -45,10 +45,10 @@ export const FileList = forwardRef(({
     const emptyContextMenu = useContextMenu();
     const dropMenu = useContextMenu();
 
-    useImperativeHandle(ref, () => ({
-        startCreateFolder: () => { setCreatingFolder(true); setNewFolderName(""); },
-        startCreateFile: () => { setCreatingFile(true); setNewFileName(""); },
-    }));
+    const startCreateFolder = useCallback(() => { setCreatingFolder(true); setNewFolderName(""); }, []);
+    const startCreateFile = useCallback(() => { setCreatingFile(true); setNewFileName(""); }, []);
+
+    useImperativeHandle(ref, () => ({ startCreateFolder, startCreateFile }));
 
     const query = searchQuery.trim().toLowerCase();
 
@@ -196,7 +196,7 @@ export const FileList = forwardRef(({
                     <p>{error}</p>
                 </div>
             ) : filteredItems.length === 0 && !creatingFolder && !creatingFile ? (
-                <div className="empty-state">
+                <div className="empty-state" onContextMenu={handleEmptyContextMenu}>
                     <Icon path={query ? mdiFileSearchOutline : mdiFolder} />
                     <h3>{t(query ? "servers.fileManager.search.noResultsTitle" : "servers.fileManager.states.emptyFolder")}</h3>
                     <p>{query
@@ -303,6 +303,9 @@ export const FileList = forwardRef(({
             </ContextMenu>
 
             <ContextMenu isOpen={emptyContextMenu.isOpen} position={emptyContextMenu.position} onClose={emptyContextMenu.close} trigger={emptyContextMenu.triggerRef}>
+                <ContextMenuItem icon={mdiFilePlus} label={t("servers.fileManager.contextMenu.newFile")} onClick={startCreateFile} />
+                <ContextMenuItem icon={mdiFolderPlus} label={t("servers.fileManager.contextMenu.newFolder")} onClick={startCreateFolder} />
+                <ContextMenuSeparator />
                 <ContextMenuItem icon={mdiFileDownload} label={t("servers.fileManager.contextMenu.downloadFolder")} onClick={() => downloadFile(path)} />
                 <ContextMenuItem icon={mdiInformationOutline} label={t("servers.fileManager.contextMenu.properties")} onClick={() => handlePropertiesClick(null)} />
                 <ContextMenuItem icon={mdiConsole} label={t("servers.fileManager.contextMenu.openTerminal")} onClick={() => handleOpenTerminal()} />


### PR DESCRIPTION
## Add New File / New Folder / Refresh Button in SFTP

Adds some improvements to the SFTP experience. Also adds refresh buttons and the option to refresh using the path breadcrumbs.

## Screenshots

<img width="1552" height="866" alt="image" src="https://github.com/user-attachments/assets/2eb2aa2e-2c76-4e42-84e5-d4755f548c3d" />


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes #1286
Closes #1376
Closes #1555