### PR TITLE
Add configurable RDP security method to support NLA/Kerberos environm…

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1640,6 +1640,11 @@
           "title": "Enable Wake-On-LAN",
           "description": "Allow waking this server remotely using its MAC address"
         },
+        "rdpSecurity": {
+          "title": "Security",
+          "description": "Authentication method used to connect to the remote Windows machine. Use NLA for environments where NTLM is disabled (e.g. Protected Users group).",
+          "method": "Security Method"
+        },
         "keyboardLayout": {
           "title": "Keyboard Layout",
           "description": "Select the keyboard layout to use for this connection."

--- a/client/src/pages/Servers/components/ServerDialog/pages/SettingsPage.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/pages/SettingsPage.jsx
@@ -3,7 +3,7 @@ import SelectBox from "@/common/components/SelectBox";
 import ToggleSwitch from "@/common/components/ToggleSwitch";
 import { ServerContext } from "@/common/contexts/ServerContext.jsx";
 import Icon from "@mdi/react";
-import { mdiServerNetwork, mdiClose, mdiPlus, mdiChartLine, mdiMonitor, mdiPalette, mdiVolumeHigh, mdiPowerPlug, mdiKeyboardOutline } from "@mdi/js";
+import { mdiServerNetwork, mdiClose, mdiPlus, mdiChartLine, mdiMonitor, mdiPalette, mdiVolumeHigh, mdiPowerPlug, mdiKeyboardOutline, mdiShieldLock } from "@mdi/js";
 import { useTranslation } from "react-i18next";
 
 const COLOR_DEPTHS = [
@@ -34,6 +34,15 @@ const FUNCTION_KEY_MODES = [
     { label: "Xterm", value: "xterm" },
     { label: "VT", value: "vt" },
     { label: "Linux", value: "linux" },
+];
+
+const RDP_SECURITY_METHODS = [
+    { label: "Auto (negotiate best)", value: "" },
+    { label: "Any (highest available)", value: "any" },
+    { label: "NLA (Kerberos / CredSSP)", value: "nla" },
+    { label: "TLS (SSL)", value: "tls" },
+    { label: "RDP (NTLM)", value: "rdp" },
+    { label: "Hyper-V (vmconnect)", value: "vmconnect" },
 ];
 
 const KEYBOARD_LAYOUTS = [
@@ -74,6 +83,7 @@ const SettingsPage = ({ config, setConfig, monitoringEnabled, setMonitoringEnabl
     const [enableDesktopComposition, setEnableDesktopComposition] = useState(config?.enableDesktopComposition === true);
     const [enableMenuAnimations, setEnableMenuAnimations] = useState(config?.enableMenuAnimations === true);
     const [wakeOnLanEnabled, setWakeOnLanEnabled] = useState(config?.wakeOnLanEnabled === true);
+    const [rdpSecurity, setRdpSecurity] = useState(config?.rdpSecurity || "");
     const [backspaceMode, setBackspaceMode] = useState(config?.backspaceMode || "del");
     const [deleteMode, setDeleteMode] = useState(config?.deleteMode || "vt");
     const [functionKeyMode, setFunctionKeyMode] = useState(config?.functionKeyMode || "xterm");
@@ -103,6 +113,7 @@ const SettingsPage = ({ config, setConfig, monitoringEnabled, setMonitoringEnabl
         if (config?.enableDesktopComposition !== undefined) setEnableDesktopComposition(config.enableDesktopComposition);
         if (config?.enableMenuAnimations !== undefined) setEnableMenuAnimations(config.enableMenuAnimations);
         if (config?.wakeOnLanEnabled !== undefined) setWakeOnLanEnabled(config.wakeOnLanEnabled);
+        if (config?.rdpSecurity !== undefined) setRdpSecurity(config.rdpSecurity);
         if (config?.backspaceMode !== undefined) setBackspaceMode(config.backspaceMode);
         if (config?.deleteMode !== undefined) setDeleteMode(config.deleteMode);
         if (config?.functionKeyMode !== undefined) setFunctionKeyMode(config.functionKeyMode);
@@ -298,6 +309,30 @@ const SettingsPage = ({ config, setConfig, monitoringEnabled, setMonitoringEnabl
                                 setSelected={(val) => handleDisplaySettingChange('functionKeyMode', val, setFunctionKeyMode)} 
                             />
                         </div>
+                    </div>
+                </div>
+            )}
+
+            {fieldConfig.showRdpSecurity && (
+                <div className="jump-hosts-section">
+                    <div className="jump-hosts-header">
+                        <div className="jump-hosts-info">
+                            <span className="jump-hosts-label">
+                                <Icon path={mdiShieldLock} size={0.8} style={{ marginRight: '8px', verticalAlign: 'middle' }} />
+                                {t('servers.dialog.settings.rdpSecurity.title')}
+                            </span>
+                            <span className="jump-hosts-description">
+                                {t('servers.dialog.settings.rdpSecurity.description')}
+                            </span>
+                        </div>
+                    </div>
+                    <div className="form-group">
+                        <label>{t('servers.dialog.settings.rdpSecurity.method')}</label>
+                        <SelectBox
+                            options={RDP_SECURITY_METHODS}
+                            selected={rdpSecurity}
+                            setSelected={(val) => handleDisplaySettingChange('rdpSecurity', val, setRdpSecurity)}
+                        />
                     </div>
                 </div>
             )}

--- a/client/src/pages/Servers/components/ServerDialog/utils/fieldConfig.js
+++ b/client/src/pages/Servers/components/ServerDialog/utils/fieldConfig.js
@@ -37,6 +37,7 @@ export const getFieldConfig = (type, protocol) => {
                     showDisplaySettings: true,
                     showPerformanceSettings: true,
                     showAudioSettings: true,
+                    showRdpSecurity: true,
                     allowedAuthTypes: ["password-only", "password"],
                     showWakeOnLan: true,
                 };

--- a/server/lib/guacParamBuilders.js
+++ b/server/lib/guacParamBuilders.js
@@ -49,6 +49,8 @@ const buildRdpParams = async (cfg, identity, accountId) => {
         if (credentials?.password) params.password = credentials.password;
     }
 
+    if (cfg.rdpSecurity) params["security"] = cfg.rdpSecurity;
+
     if (cfg.colorDepth) params["color-depth"] = String(cfg.colorDepth);
     if (cfg.enableWallpaper !== false) params["enable-wallpaper"] = "true";
     if (cfg.enableTheming !== false) params["enable-theming"] = "true";

--- a/server/validations/server.js
+++ b/server/validations/server.js
@@ -8,6 +8,7 @@ const configValidation = Joi.object({
     monitoringEnabled: Joi.boolean().optional(),
     nodeName: Joi.string().optional(),
     vmid: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
+    rdpSecurity: Joi.string().valid("any", "nla", "tls", "rdp", "vmconnect").allow("").optional(),
     jumpHosts: Joi.array().items(Joi.number()).optional(),
     macAddress: Joi.string().pattern(/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/).allow("").optional(),
     wakeOnLanEnabled: Joi.boolean().optional(),


### PR DESCRIPTION
## Summary

- Adds a **Security Method** dropdown in RDP connection settings (Settings tab)
- Exposes Guacamole's `security` parameter: `any`, `nla`, `tls`, `rdp`, `vmconnect`
- Backend validation and param forwarding updated accordingly

## Motivation

Fixes #1556 — RDP connections fail when NTLM is disabled (e.g. Windows accounts in the
Protected Users AD group). Users can now select **NLA (Kerberos / CredSSP)** to
authenticate without NTLM.

## Changes

- `server/lib/guacParamBuilders.js` — pass `security` param to Guacamole when set
- `server/validations/server.js` — allow `rdpSecurity` field in config
- `client/.../SettingsPage.jsx` — Security Method selector UI
- `client/.../fieldConfig.js` — enable security section for RDP protocol
- `client/public/assets/locales/en.json` — translation strings