### PR TITLE
refactor(server): login() mixes too many responsibilities and repeats error messages

### DIFF
--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -8,55 +8,75 @@ const logger = require("../utils/logger");
 const stateBroadcaster = require("../lib/StateBroadcaster");
 const sessionManager = require("../lib/SessionManager");
 
-module.exports.login = async (configuration, user) => {
-    const internalProvider = await OIDCProvider.findOne({ where: { isInternal: true, enabled: true } });
-    const ldapProvider = await getLdapProvider();
+// Login response codes (application-specific, not HTTP status codes)
+const LOGIN_FAILED = 201;
+const TOTP_REQUIRED = 202;
+const TOTP_INVALID = 203;
+const TOKEN_INVALID = 204;
+const NO_LOGIN_METHOD = 403;
 
-    if (!internalProvider && !ldapProvider) {
-        return { code: 403, message: "No login method is enabled" };
+const USERNAME_OR_PASSWORD_INCORRECT = "Username or password incorrect";
+
+const verifyInternalCredentials = async (account, password) => {
+    if (!account) {
+        return { code: LOGIN_FAILED, message: USERNAME_OR_PASSWORD_INCORRECT };
     }
-
-    if (ldapProvider) {
-        const ldapResult = await ldapAuth(configuration.username, configuration.password, user);
-        if (ldapResult) return ldapResult;
-        return { code: 201, message: "Username or password incorrect" };
+    if (!(await compare(password, account.password))) {
+        return { code: LOGIN_FAILED, message: USERNAME_OR_PASSWORD_INCORRECT };
     }
+    return null;
+};
 
-    const account = await Account.findOne({ where: { username: configuration.username } });
-
-    // Check if account exists
-    if (account === null)
-        return { code: 201, message: "Username or password incorrect" };
-
-    // Check if password is correct
-    if (!(await compare(configuration.password, account.password)))
-        return { code: 201, message: "Username or password incorrect" };
-
-    // Check if TOTP is required
-    if (account.totpEnabled && !configuration.code)
-        return { code: 202, message: "TOTP is required for this account" };
-
-    // Check if TOTP is correct
-    if (account.totpEnabled) {
-        const tokenCorrect = speakeasy.totp.verify({
-            secret: account.totpSecret || "",
-            encoding: "base32",
-            token: configuration.code,
-        });
-
-        if (!tokenCorrect)
-            return { code: 203, message: "Your provided code is invalid or has expired." };
+const verifyTotp = (account, code) => {
+    if (!account.totpEnabled) {
+        return null;
     }
+    if (!code) {
+        return { code: TOTP_REQUIRED, message: "TOTP is required for this account" };
+    }
+    const tokenCorrect = speakeasy.totp.verify({
+        secret: account.totpSecret || "",
+        encoding: "base32",
+        token: code,
+    });
+    if (!tokenCorrect) {
+        return { code: TOTP_INVALID, message: "Your provided code is invalid or has expired." };
+    }
+    return null;
+};
 
-    // Create Session
+const createSessionFor = async (account, user) => {
     const session = await Session.create({
         accountId: account.id,
         ip: user.ip,
         userAgent: user.userAgent,
     });
-
     logger.system(`User ${account.username} logged in`, { accountId: account.id, ip: user.ip });
+    return session;
+};
 
+module.exports.login = async (configuration, user) => {
+    const internalProvider = await OIDCProvider.findOne({ where: { isInternal: true, enabled: true } });
+    const ldapProvider = await getLdapProvider();
+
+    if (!internalProvider && !ldapProvider) {
+        return { code: NO_LOGIN_METHOD, message: "No login method is enabled" };
+    }
+
+    if (ldapProvider) {
+        const ldapResult = await ldapAuth(configuration.username, configuration.password, user);
+        if (ldapResult) return ldapResult;
+        return { code: LOGIN_FAILED, message: USERNAME_OR_PASSWORD_INCORRECT };
+    }
+
+    const account = await Account.findOne({ where: { username: configuration.username } });
+    const credError = await verifyInternalCredentials(account, configuration.password);
+    if (credError) return credError;
+
+    const totpError = verifyTotp(account, configuration.code);
+    if (totpError) return totpError;
+
+    const session = await createSessionFor(account, user);
     return { token: session.token, totpRequired: account.totpEnabled };
 };
 
@@ -64,7 +84,7 @@ module.exports.logout = async token => {
     const session = await Session.findOne({ where: { token } });
 
     if (session === null)
-        return { code: 204, message: "Your session token is invalid" };
+        return { code: TOKEN_INVALID, message: "Your session token is invalid" };
 
     logger.system(`User logged out`, { accountId: session.accountId });
 


### PR DESCRIPTION
## Refactoring

### Problem
The login function in server/controllers/auth.js is ~50 lines and sequentially handles: provider availability check, LDAP authentication, account lookup, password verification, TOTP requirement check, TOTP verification, and session creation. It also repeats the exact string "Username or password incorrect" three times and uses raw numeric codes (201, 202, 203, 204, 403) as a bespoke status protocol that gets returned to the caller. The repeated string is a DRY violation, and the magic numbers are easy to confuse with HTTP status codes (e.g. 201 normally means "Created"). Extracting helpers would make the flow read top-to-bottom and make the response protocol explicit.

**Severity**: `high`
**File**: `server/controllers/auth.js`

### Solution
Extract helpers such as `verifyInternalCredentials(account, password)`, `verifyTotp(account, code)`, and `createSessionFor(account, request)`; introduce named constants for the protocol codes (e.g. `LOGIN_FAILED`, `TOTP_REQUIRED`, `TOTP_INVALID`, `TOKEN_INVALID`, `NO_LOGIN_METHOD`); and hoist the `USERNAME_OR_PASSWORD_INCORRECT` message into a single constant. The body of `login` then becomes a short orchestration: check providers -> verify credentials -> verify TOTP -> issue session.

### Changes
- `server/controllers/auth.js` (modified)

## 📋 Description

Please include a summary of the changes and the related issue. Explain the problem that you are solving and provide the
necessary context.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have looked for similar pull requests in the repository and found none
- [ ] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues 

Fixes #(issue)
Contributed by Hoàng Anh Vũ

Closes #1618