### PR TITLE
refactor(client): create the main recordingplayer component that detects recording type and renders appropriate viewer

### DIFF
--- a/client/src/common/components/RecordingPlayer/RecordingPlayer.jsx
+++ b/client/src/common/components/RecordingPlayer/RecordingPlayer.jsx
@@ -1,0 +1,173 @@
+import { useEffect, useState, useRef } from "react";
+import "asciinema-player/dist/bundle/asciinema-player.css";
+
+const RecordingPlayer = ({ url, type: forcedType }) => {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [recordingData, setRecordingData] = useState(null);
+    const playerRef = useRef(null);
+    const containerRef = useRef(null);
+
+    const detectType = (url, forcedType) => {
+        if (forcedType) return forcedType;
+
+        const extension = url.split("?")[0].split(".").pop().toLowerCase();
+        if (extension === "cast") return "asciinema";
+        if (extension === "guac") return "guacamole";
+        if (extension === "gz") {
+            const baseName = url.split("?")[0].split(".").slice(-2)[0].toLowerCase();
+            if (baseName === "cast") return "asciinema";
+            if (baseName === "guac") return "guacamole";
+        }
+        return "asciinema";
+    };
+
+    const decompressGz = async (arrayBuffer) => {
+        const stream = new Blob([arrayBuffer]).stream();
+        const decompressedStream = stream.pipeThrough(new DecompressionStream("gzip"));
+        const reader = decompressedStream.getReader();
+        const chunks = [];
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            chunks.push(value);
+        }
+
+        const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+        const result = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const chunk of chunks) {
+            result.set(chunk, offset);
+            offset += chunk.length;
+        }
+
+        return result;
+    };
+
+    const loadRecording = async () => {
+        try {
+            setLoading(true);
+            setError(null);
+
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`Failed to load recording: ${response.status}`);
+            }
+
+            const arrayBuffer = await response.arrayBuffer();
+            const recordingType = detectType(url, forcedType);
+            const isGzipped = url.toLowerCase().endsWith(".gz");
+
+            let data;
+            if (isGzipped) {
+                data = await decompressGz(arrayBuffer);
+            } else {
+                data = new Uint8Array(arrayBuffer);
+            }
+
+            const text = new TextDecoder("utf-8").decode(data);
+
+            setRecordingData({
+                type: recordingType,
+                content: text,
+                raw: data,
+            });
+        } catch (err) {
+            setError(err.message || "Failed to load recording");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (url) {
+            loadRecording();
+        }
+
+        return () => {
+            if (playerRef.current) {
+                playerRef.current = null;
+            }
+        };
+    }, [url, forcedType]);
+
+    useEffect(() => {
+        if (recordingData?.type === "asciinema" && containerRef.current && !playerRef.current) {
+            const loadAsciinema = async () => {
+                const { default: AsciinemaPlayer } = await import("asciinema-player");
+
+                playerRef.current = AsciinemaPlayer.create(recordingData.content, containerRef.current, {
+                    autoPlay: true,
+                    loop: true,
+                    preload: true,
+                    fit: false,
+                    fontSize: "small",
+                    theme: "monokai",
+                });
+            };
+
+            loadAsciinema();
+        }
+    }, [recordingData]);
+
+    if (loading) {
+        return (
+            <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                color: "var(--text-secondary, #9ca3af)"
+            }}>
+                Loading recording...
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                color: "var(--color-error, #ef4444)"
+            }}>
+                {error}
+            </div>
+        );
+    }
+
+    if (recordingData?.type === "asciinema") {
+        return <div ref={containerRef} style={{ width: "100%", height: "100%" }} />;
+    }
+
+    if (recordingData?.type === "guacamole") {
+        return (
+            <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                color: "var(--text-secondary, #9ca3af)"
+            }}>
+                Guacamole recordings are not yet supported in the web client.
+            </div>
+        );
+    }
+
+    return (
+        <div style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            color: "var(--text-secondary, #9ca3af)"
+        }}>
+            Unknown recording format.
+        </div>
+    );
+};
+
+export default RecordingPlayer;


### PR DESCRIPTION
## Code Quality

### Problem
A new component responsible for loading a recording file (from a URL provided by the server), detecting whether it is an asciinema (.cast/.cast.gz) or Guacamole (.guac.gz) recording, decompressing it if necessary, and delegating rendering to the proper sub-viewer.

**Severity**: `critical`
**File**: `client/src/common/components/RecordingPlayer/RecordingPlayer.jsx`

### Solution
Create a file that:

### Changes
- `client/src/common/components/RecordingPlayer/RecordingPlayer.jsx` (new)

## 📋 Description

Please include a summary of the changes and the related issue. Explain the problem that you are solving and provide the
necessary context.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have looked for similar pull requests in the repository and found none
- [ ] This pull request does not contain translations (translations are managed through Crowdin)

## 🔗 Related Issues 

Fixes #(issue)
Contributed by Hoàng Anh Vũ

Closes #1596