### PR TITLE
fix(sessions): require ownership for hibernate, resume, and delete

### DIFF
--- a/server/controllers/serverSession.js
+++ b/server/controllers/serverSession.js
@@ -175,7 +175,17 @@ const getSessions = async (accountId, tabId = null, browserId = null) => {
     });
 };
 
-const hibernateSession = (sessionId) => {
+const validateSessionOwnership = (accountId, sessionId) => {
+    const session = SessionManager.get(sessionId);
+    if (!session) return { error: { code: 404, message: "Session not found" } };
+    if (session.accountId !== accountId) return { error: { code: 403, message: "Access denied" } };
+    return { session };
+};
+
+const hibernateSession = (accountId, sessionId) => {
+    const { error } = validateSessionOwnership(accountId, sessionId);
+    if (error) return error;
+
     const success = SessionManager.hibernate(sessionId);
     if (success) {
         return { message: "Session hibernated" };
@@ -183,7 +193,10 @@ const hibernateSession = (sessionId) => {
     return { code: 404, message: "Session not found" };
 };
 
-const resumeSession = (sessionId, tabId = null, browserId = null) => {
+const resumeSession = (accountId, sessionId, tabId = null, browserId = null) => {
+    const { error } = validateSessionOwnership(accountId, sessionId);
+    if (error) return error;
+
     const success = SessionManager.resume(sessionId, tabId, browserId);
     if (success) {
         return { message: "Session resumed" };
@@ -191,8 +204,11 @@ const resumeSession = (sessionId, tabId = null, browserId = null) => {
     return { code: 404, message: "Session not found" };
 };
 
-const deleteSession = (sessionId) => {
-    const success = SessionManager.remove(sessionId);
+const deleteSession = async (accountId, sessionId) => {
+    const { error } = validateSessionOwnership(accountId, sessionId);
+    if (error) return error;
+
+    const success = await SessionManager.remove(sessionId);
     if (success) {
         return { message: "Session deleted" };
     }
@@ -244,13 +260,6 @@ const getSession = async (accountId, sessionId) => {
         shareId: session.shareId || null,
         shareWritable: session.shareWritable || false,
     };
-};
-
-const validateSessionOwnership = (accountId, sessionId) => {
-    const session = SessionManager.get(sessionId);
-    if (!session) return { error: { code: 404, message: "Session not found" } };
-    if (session.accountId !== accountId) return { error: { code: 403, message: "Access denied" } };
-    return { session };
 };
 
 const startSharing = (accountId, sessionId, writable = false) => {

--- a/server/routes/serverSession.js
+++ b/server/routes/serverSession.js
@@ -84,7 +84,7 @@ app.get("/:id", async (req, res) => {
 app.post("/:id/hibernate", async (req, res) => {
     if (validateSchema(res, sessionIdValidation, req.params)) return;
     
-    const result = await hibernateSession(req.params.id);
+    const result = await hibernateSession(req.user.id, req.params.id);
     if (result?.code) {
         return res.status(result.code).json({ error: result.message });
     }
@@ -107,7 +107,7 @@ app.post("/:id/resume", async (req, res) => {
     if (validateSchema(res, resumeSessionValidation, req.body)) return;
     
     const { tabId, browserId } = req.body;
-    const result = await resumeSession(req.params.id, tabId, browserId);
+    const result = await resumeSession(req.user.id, req.params.id, tabId, browserId);
     if (result?.code) {
         return res.status(result.code).json({ error: result.message });
     }
@@ -128,7 +128,7 @@ app.post("/:id/resume", async (req, res) => {
 app.delete("/:id", async (req, res) => {
     if (validateSchema(res, sessionIdValidation, req.params)) return;
     
-    const result = await deleteSession(req.params.id);
+    const result = await deleteSession(req.user.id, req.params.id);
     if (result?.code) {
         return res.status(result.code).json({ error: result.message });
     }


### PR DESCRIPTION
## Summary
- Enforce account ownership on `POST /connections/:id/hibernate`, `POST /connections/:id/resume`, and `DELETE /connections/:id`
- Reuse the existing `validateSessionOwnership` helper already used by share/paste-password flows
- Await async `SessionManager.remove` so delete reports the real outcome

## Why
`GET /connections/:id`, share, and paste-password already reject cross-account access, but hibernate/resume/delete did not. Any authenticated user who knows (or guesses) a `sessionId` could hibernate or terminate another user's live session. Shared-session URLs expose the session id, which makes this practical.

## Test plan
- [x] Owner can still hibernate, resume, and delete their own connection
- [x] Second authenticated account calling the same endpoints with that session id receives `403 Access denied`
- [x] Missing session id still returns `404`
- [x] Share start/stop/update and paste-password continue to work unchanged