### PR TITLE
Fix line endings in transformScript function

### DIFF
--- a/server/utils/scriptUtils.js
+++ b/server/utils/scriptUtils.js
@@ -25,7 +25,7 @@ const checkSudoPrompt = (output) => {
 
 const transformScript = (content) => {
     const esc = (t) => t.replace(/:/g, "\\x3A");
-    let t = content
+    let t = content.replace(/\r\n?/g, "\n")
         .replace(/^(\s*)sudo(?!\s+-S)(\s+)/gm, "$1sudo -S$2")
         .replace(/^(\s*)@NEXTERM:STEP\s+"((?:\\.|[^"\\])*)"/gm, "$1echo \"NEXTERM_STEP:$2\"")
         .replace(/^(\s*)@NEXTERM:INPUT\s+(\S+)\s+"((?:\\.|[^"\\])*)"(?:\s+"((?:\\.|[^"\\]*)*)")?/gm, (_, i, v, p, d) =>


### PR DESCRIPTION
## 📋 Description

Browser <textarea> can normalize line endings to CRLF even when copying LF text, this normalizes CRLF and bare CR line endings before Nexterm processes @NEXTERM: directives.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

<!-- Link any related issues here, for example: Fixes #123 -->
