### PR TITLE
Sidebar collapse improvements

### DIFF
--- a/client/src/common/layouts/Root.jsx
+++ b/client/src/common/layouts/Root.jsx
@@ -24,6 +24,7 @@ import ConnectionErrorBanner from "@/common/components/ConnectionErrorBanner";
 import { waitForTauri } from "@/common/utils/TauriUtil.js";
 import MobileNav from "@/common/components/MobileNav";
 import ThemeLoader from "@/common/components/ThemeLoader";
+import { patchRequest } from "@/common/utils/RequestUtil.js";
 
 const Sidebar = lazy(() => import("@/common/components/Sidebar"));
 
@@ -37,11 +38,19 @@ const PreferencesWrapper = ({ children }) => {
 };
 
 const AppContent = () => {
+    const { user } = useContext(UserContext);
     const [tauriReady, setTauriReady] = useState(false);
     const [isLeftPaneCollapsed, setIsLeftPaneCollapsed] = useState(false);
     const [isLeftPaneHovering, setIsLeftPaneHovering] = useState(false);
     const leftPaneRef = useRef(null);
-    const hoverBarRef = useRef(null);
+
+    const toggleLeftPane = () => {
+        const nextCollapsed = !isLeftPaneCollapsed;
+        setIsLeftPaneHovering(false);
+        setIsLeftPaneCollapsed(nextCollapsed);
+        patchRequest("accounts/me/preferences", { general: { sidebarCollapsed: nextCollapsed } })
+            .catch(error => console.error("Failed to save sidebar preference:", error));
+    };
 
     useEffect(() => {
         waitForTauri().then(() => {
@@ -49,29 +58,23 @@ const AppContent = () => {
         });
     }, []);
     useEffect(() => {
+        setIsLeftPaneCollapsed(user?.preferences?.general?.sidebarCollapsed === true);
+    }, [user?.id]);
+    useEffect(() => {
         if (!isLeftPaneCollapsed) return;
-        const isPointInRect = (rect, x, y) => rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+
+        const containsPoint = (rect, x, y) => rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
         const handleMouseMove = (event) => {
             const leftPaneRect = leftPaneRef.current?.getBoundingClientRect();
-            const hoverBarRect = hoverBarRef.current?.getBoundingClientRect();
-            const isOverLeftPane = isPointInRect(leftPaneRect, event.clientX, event.clientY);
-            const isOverHoverBar = isPointInRect(hoverBarRect, event.clientX, event.clientY);
-            const nextHovering = Boolean(isOverLeftPane || isOverHoverBar);
-            setIsLeftPaneHovering(prev => (prev === nextHovering ? prev : nextHovering));
+            const serverListRect = document.querySelector(".server-list")?.getBoundingClientRect();
+            const hovering = containsPoint(leftPaneRect, event.clientX, event.clientY)
+                || containsPoint(serverListRect, event.clientX, event.clientY);
+            setIsLeftPaneHovering(current => current === hovering ? current : hovering);
         };
-        const handleMouseOut = (event) => {
-            if (!event.relatedTarget) {
-                setIsLeftPaneHovering(false);
-            }
-        };
-        document.addEventListener("mousemove", handleMouseMove);
-        window.addEventListener("mouseout", handleMouseOut);
-        return () => {
-            document.removeEventListener("mousemove", handleMouseMove);
-            window.removeEventListener("mouseout", handleMouseOut);
-        };
-    }, [isLeftPaneCollapsed]);
 
+        document.addEventListener("mousemove", handleMouseMove);
+        return () => document.removeEventListener("mousemove", handleMouseMove);
+    }, [isLeftPaneCollapsed]);
     if (!tauriReady) {
         return (
             <div className="app-wrapper">
@@ -84,8 +87,7 @@ const AppContent = () => {
     const isLeftPaneVisible = !isLeftPaneCollapsed || isLeftPaneHovering;
 
     return (
-        <UserProvider>
-            <PreferencesWrapper>
+        <PreferencesWrapper>
                 <ThemeLoader />
                 <StateStreamProvider>
                     <LiveSessionProvider>
@@ -107,14 +109,13 @@ const AppContent = () => {
                                                                 ref={leftPaneRef}
                                                             >
                                                                 <Suspense fallback={<Loading />}>
-                                                                    <Sidebar onToggleCollapse={() => setIsLeftPaneCollapsed(prev => !prev)} />
+                                                                    <Sidebar onToggleCollapse={toggleLeftPane} />
                                                                 </Suspense>
-                                                                <div className="left-pane-slot" id="left-pane-slot" />
+                                                                <div
+                                                                    className="left-pane-slot"
+                                                                    id="left-pane-slot"
+                                                                />
                                                             </div>
-                                                            <div
-                                                                className={`left-pane-hover-bar${isLeftPaneCollapsed ? " active" : ""}`}
-                                                                ref={hoverBarRef}
-                                                            />
                                                             <div className="main-content">
                                                                 <Suspense fallback={<Loading />}>
                                                                     <Outlet />
@@ -134,8 +135,7 @@ const AppContent = () => {
                     </KeymapProvider>
                     </LiveSessionProvider>
                 </StateStreamProvider>
-            </PreferencesWrapper>
-        </UserProvider>
+        </PreferencesWrapper>
     );
 };
 
@@ -144,7 +144,9 @@ export default () => {
         <ErrorBoundary>
             <DndProvider backend={HTML5Backend}>
                 <ToastProvider>
-                    <AppContent />
+                    <UserProvider>
+                        <AppContent />
+                    </UserProvider>
                 </ToastProvider>
             </DndProvider>
         </ErrorBoundary>

--- a/client/src/common/styles/main.sass
+++ b/client/src/common/styles/main.sass
@@ -65,46 +65,35 @@ body.tauri-mode
   display: flex
   align-items: stretch
   z-index: 30
-  transform: translateX(0)
-  transition: transform 0.2s ease, box-shadow 0.2s ease
+  transition: box-shadow 0.2s ease
   flex-shrink: 0
 
   &.collapsed
-    position: absolute
-    transform: translateX(-100%)
-    box-shadow: none
-    pointer-events: none
+    .left-pane-slot
+      position: absolute
+      left: 100%
+      top: 0
+      visibility: hidden
+      opacity: 0
+      pointer-events: none
+      transform: translateX(-0.5rem)
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease
 
-  &.collapsed.open
-    transform: translateX(0)
-    box-shadow: colors.$shadow-lg
-    pointer-events: auto
-
-  &.collapsed
     .resizer
       display: none
+
+  &.collapsed.open
+    .left-pane-slot
+      visibility: visible
+      opacity: 1
+      pointer-events: auto
+      transform: translateX(0)
+      box-shadow: colors.$shadow-lg
 
 .left-pane-slot
   display: flex
   height: 100%
 
-.left-pane-hover-bar
-  width: 10px
-  height: 100%
-  flex-shrink: 0
-  background-color: colors.$lighter-background
-  border-right: 1px solid colors.$lighter-background
-  cursor: pointer
-  opacity: 0.6
-  transition: opacity 0.15s ease, background-color 0.15s ease
-  display: none
-
-  &.active
-    display: block
-
-  &:hover
-    opacity: 1
-    background-color: colors.$gray
 
 .sidebar
   width: calc(5rem + 2px)
@@ -123,9 +112,6 @@ body.tauri-mode
     transform: none
     box-shadow: none
     pointer-events: auto
-
-  .left-pane-hover-bar
-    display: none
 
 ::-webkit-scrollbar
   width: 13px

--- a/server/validations/preferences.js
+++ b/server/validations/preferences.js
@@ -25,6 +25,7 @@ const filesSchema = Joi.object({
 
 const generalSchema = Joi.object({
     language: Joi.string().max(10),
+    sidebarCollapsed: Joi.boolean(),
 }).unknown(false);
 
 module.exports.preferencesValidation = Joi.object({


### PR DESCRIPTION
## 📋 Description

Removes the small sidebar strip on collapse, and uses the sidebar menu itself as the server list expand trigger.

Additionally, the sidebar collapse state is saved to user preferences so the state syncs across refreshes and across browsers.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

<!-- Link any related issues here, for example: Fixes #123 -->
