### PR TITLE
feat(telnet): add prompt-based identity login

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1677,6 +1677,12 @@
           "removeTooltip": "Remove jump host",
           "noServersAvailable": "No SSH servers available for jump hosts. Create SSH servers first."
         },
+        "telnetAutoLogin": {
+          "title": "Telnet automatic login",
+          "description": "Attach a saved password identity and enter the exact prompts emitted by the device. Credentials are sent only after their matching prompt appears. Telnet transmits credentials unencrypted.",
+          "usernamePrompt": "Username prompt",
+          "passwordPrompt": "Password prompt"
+        },
         "monitoring": {
           "title": "Enable Performance Monitoring",
           "description": "Collect CPU, memory, disk, and network metrics for this server"

--- a/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/ServerDialog.jsx
@@ -148,6 +148,11 @@ export const ServerDialog = ({ open, onClose, currentFolderId, currentOrganizati
         if (!fieldConfig.showKeyboardLayout) {
             delete finalConfig.keyboardLayout;
         }
+
+        if (finalConfig.protocol !== "telnet") {
+            delete finalConfig.telnetUsernamePrompt;
+            delete finalConfig.telnetPasswordPrompt;
+        }
         
         return finalConfig;
     };

--- a/client/src/pages/Servers/components/ServerDialog/pages/SettingsPage.jsx
+++ b/client/src/pages/Servers/components/ServerDialog/pages/SettingsPage.jsx
@@ -171,8 +171,9 @@ const SettingsPage = ({ config, setConfig, monitoringEnabled, setMonitoringEnabl
     };
 
     const showJumpHosts = config?.protocol === 'ssh';
+    const showTelnetAutoLogin = config?.protocol === 'telnet';
 
-    if (!fieldConfig.showMonitoring && !fieldConfig.showKeyboardLayout && !fieldConfig.showDisplaySettings && !fieldConfig.showAudioSettings && !fieldConfig.showWakeOnLan && !fieldConfig.showTerminalSettings && !showJumpHosts) {
+    if (!fieldConfig.showMonitoring && !fieldConfig.showKeyboardLayout && !fieldConfig.showDisplaySettings && !fieldConfig.showAudioSettings && !fieldConfig.showWakeOnLan && !fieldConfig.showTerminalSettings && !showJumpHosts && !showTelnetAutoLogin) {
         return <p className="text-center">{t('servers.dialog.settings.noSettings')}</p>;
     }
 
@@ -237,6 +238,33 @@ const SettingsPage = ({ config, setConfig, monitoringEnabled, setMonitoringEnabl
                             {t('servers.dialog.settings.jumpHosts.noServersAvailable')}
                         </p>
                     )}
+                </div>
+            )}
+
+            {showTelnetAutoLogin && (
+                <div className="jump-hosts-section">
+                    <div className="jump-hosts-header">
+                        <div className="jump-hosts-info">
+                            <span className="jump-hosts-label">{t('servers.dialog.settings.telnetAutoLogin.title')}</span>
+                            <span className="jump-hosts-description">{t('servers.dialog.settings.telnetAutoLogin.description')}</span>
+                        </div>
+                    </div>
+                    <div className="form-group">
+                        <label>{t('servers.dialog.settings.telnetAutoLogin.usernamePrompt')}</label>
+                        <input
+                            className="form-input"
+                            value={config?.telnetUsernamePrompt || ''}
+                            onChange={(event) => setConfig(prev => ({ ...prev, telnetUsernamePrompt: event.target.value }))}
+                        />
+                    </div>
+                    <div className="form-group">
+                        <label>{t('servers.dialog.settings.telnetAutoLogin.passwordPrompt')}</label>
+                        <input
+                            className="form-input"
+                            value={config?.telnetPasswordPrompt || ''}
+                            onChange={(event) => setConfig(prev => ({ ...prev, telnetPasswordPrompt: event.target.value }))}
+                        />
+                    </div>
                 </div>
             )}
 

--- a/client/src/pages/Servers/components/ServerDialog/utils/fieldConfig.js
+++ b/client/src/pages/Servers/components/ServerDialog/utils/fieldConfig.js
@@ -19,11 +19,12 @@ export const getFieldConfig = (type, protocol) => {
                 return {
                     showProtocol: false,
                     showIpPort: true,
-                    showIdentities: false,
+                    showIdentities: true,
                     showSettings: true,
                     showMonitoring: false,
                     showKeyboardLayout: false,
                     showTerminalSettings: true,
+                    allowedAuthTypes: ["password", "password-only"],
                     showWakeOnLan: true,
                 };
             case "rdp":

--- a/server/lib/ConnectionService.js
+++ b/server/lib/ConnectionService.js
@@ -47,6 +47,47 @@ const buildSSHParams = (identity, credentials) => {
     return params;
 };
 
+// Telnet has no authentication handshake. Credentials are sent only after the
+// explicitly configured prompts appear in the terminal stream. Entries without
+// prompts (or without an identity) remain manual Telnet sessions.
+const buildTelnetParams = (identity, credentials, serverConfig = null) => {
+    if (!identity) return {};
+
+    const params = { username: identity.username || credentials.username || "" };
+    if (credentials.password) params.password = credentials.password;
+    const usernamePrompt = serverConfig?.telnetUsernamePrompt?.trim();
+    const passwordPrompt = serverConfig?.telnetPasswordPrompt?.trim();
+    if (usernamePrompt) params.usernamePrompt = usernamePrompt;
+    if (passwordPrompt) params.passwordPrompt = passwordPrompt;
+    return params;
+};
+
+const createTelnetPromptLoginHandler = (dataSocket, params, context) => {
+    if (!params.username || !params.password || !params.usernamePrompt || !params.passwordPrompt) return null;
+
+    let buffer = "";
+    let state = "username";
+    const { sessionId, ip, port } = context;
+
+    return (data) => {
+        if (state === "complete") return;
+        buffer = `${buffer}${data.toString()}`.slice(-8192);
+
+        if (state === "username" && buffer.includes(params.usernamePrompt)) {
+            dataSocket.write(`${params.username}\r\n`);
+            state = "password";
+            logger.info("Telnet username prompt matched", { sessionId, target: ip, port });
+            return;
+        }
+
+        if (state === "password" && buffer.includes(params.passwordPrompt)) {
+            dataSocket.write(`${params.password}\r\n`);
+            state = "complete";
+            logger.info("Telnet password prompt matched", { sessionId, target: ip, port });
+        }
+    };
+};
+
 const extractIdentity = (identityResult) => {
     return identityResult?.identity === undefined ? identityResult : identityResult.identity;
 };
@@ -124,7 +165,7 @@ const createConnectionForSession = async (sessionId, accountId) => {
 
     switch (protocol) {
         case "ssh": return createSSHConnectionForSession(sessionId, entry, identity, organizationId, script);
-        case "telnet": return createTelnetConnectionForSession(sessionId, entry, organizationId);
+        case "telnet": return createTelnetConnectionForSession(sessionId, entry, identity, organizationId);
         case "pve-lxc":
         case "pve-shell": return createPveLxcConnectionForSession(sessionId, entry, organizationId);
         case "pve-qemu":
@@ -310,20 +351,26 @@ const createSSHConnectionForSession = async (sessionId, entry, identity, organiz
     return session._connecting;
 };
 
-const createTelnetConnectionForSession = async (sessionId, entry, organizationId) => {
+const createTelnetConnectionForSession = async (sessionId, entry, identity, organizationId) => {
     requireEngine();
     const session = requireSession(sessionId);
     const { ip, port = 23 } = entry.config || {};
 
     if (!ip) throw new Error("Missing host configuration");
 
+    const credentials = identity ? await resolveCredentials(identity) : {};
+    const params = buildTelnetParams(identity, credentials, entry.config);
     const dataSocket = await openEngineSession(
-        sessionId, SessionType.Telnet, ip, port, {}, entry.config?.engineId
+        sessionId, SessionType.Telnet, ip, port, params, [], entry.config?.engineId
     );
 
     await SessionManager.initRecording(sessionId, organizationId);
 
-    dataSocket.on("data", (data) => SessionManager.appendLog(sessionId, data.toString()));
+    const promptLoginHandler = createTelnetPromptLoginHandler(dataSocket, params, { sessionId, ip, port });
+    dataSocket.on("data", (data) => {
+        SessionManager.appendLog(sessionId, data.toString());
+        promptLoginHandler?.(data);
+    });
     dataSocket.on("close", () => {
         logger.info("Telnet data connection closed", { sessionId });
         SessionManager.remove(sessionId);
@@ -341,7 +388,12 @@ const createTelnetConnectionForSession = async (sessionId, entry, organizationId
         auditLogId: session.auditLogId,
     });
 
-    logger.info("Telnet connected", { sessionId, ip, port });
+    logger.info("Telnet connected", {
+        sessionId,
+        ip,
+        port,
+        autoLogin: Boolean(promptLoginHandler),
+    });
     return { success: true };
 }
 
@@ -542,5 +594,7 @@ module.exports = {
     getSFTPAIClient,
     getSessionPassword,
     buildSSHParams,
+    buildTelnetParams,
+    createTelnetPromptLoginHandler,
     resolveJumpHosts,
 };


### PR DESCRIPTION
## 📋 Description

Adds optional prompt-based automatic login for Telnet servers that use a saved password identity. The username is written only after the configured username prompt is received, and the password only after the configured password prompt is received. If either prompt or a usable identity is absent, the session stays fully manual.

## 🚀 Changes made to

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

### Behaviour and security

- Enables password and password-only identities for Telnet entries.
- Adds optional per-server username and password prompt fields.
- Uses sequential prompt matching with a bounded 8192-character terminal buffer.
- Does not write or log credentials before their matching prompt appears.
- Keeps Telnet manual by default; automatic login requires both prompts and an attached usable identity.
- Makes the existing Telnet engine-selection argument unambiguous by passing an empty jump-host list before the selected engine ID.
- The UI explicitly warns that Telnet transports credentials unencrypted.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

### Validation

- Verified JSON syntax and clean diff.
- Unit-tested prompt sequencing: username only after `login:`, password only after `Password:`.
- Verified the manual fallback when prompts are omitted.
- Functionally tested in an isolated Nexterm deployment.

## 🔗 Related Issues

Refs #1239
