### PR TITLE
fix: encrypt TOTP secrets at rest

### DIFF
--- a/server/controllers/account.js
+++ b/server/controllers/account.js
@@ -253,7 +253,7 @@ module.exports.listUsers = async (options = {}) => {
     const [users, total] = await Promise.all([
         Account.findAll({
             where: whereClause,
-            attributes: { exclude: ["password", "totpSecret", "preferences", "sessionSync"] },
+            attributes: { exclude: ["password", "totpSecret", "totpSecretIV", "totpSecretAuthTag", "preferences", "sessionSync"] },
             limit: parseInt(limit),
             offset: parseInt(offset),
             order: [["id", "DESC"]],

--- a/server/migrations/0042-encrypt-totp-secret.js
+++ b/server/migrations/0042-encrypt-totp-secret.js
@@ -1,0 +1,44 @@
+const { encrypt } = require("../utils/encryption");
+const logger = require("../utils/logger");
+const { DataTypes } = require("sequelize");
+
+module.exports = {
+    async up(queryInterface) {
+        if (!process.env.ENCRYPTION_KEY) {
+            throw new Error("ENCRYPTION_KEY environment variable is not set. Please set it to run migrations.");
+        }
+
+        if (!/^[0-9a-fA-F]{64}$/.test(process.env.ENCRYPTION_KEY)) {
+            throw new Error("ENCRYPTION_KEY must be a 64-character hexadecimal string.");
+        }
+
+        const alreadyMigrated = await queryInterface.describeTable("accounts").then((table) => table.totpSecretAuthTag !== undefined);
+
+        if (alreadyMigrated) {
+            logger.info("Migration already applied: totpSecretAuthTag column exists.");
+            return;
+        }
+
+        await queryInterface.addColumn("accounts", "totpSecretIV", {
+            type: DataTypes.STRING,
+            allowNull: true,
+        });
+        await queryInterface.addColumn("accounts", "totpSecretAuthTag", {
+            type: DataTypes.STRING,
+            allowNull: true,
+        });
+
+        const [accounts] = await queryInterface.sequelize.query("SELECT id, totpSecret FROM accounts");
+
+        for (const account of accounts) {
+            if (!account.totpSecret) continue;
+
+            const encrypted = encrypt(account.totpSecret);
+            await queryInterface.sequelize.query(
+                "UPDATE accounts SET totpSecret = ?, totpSecretIV = ?, totpSecretAuthTag = ? WHERE id = ?",
+                { replacements: [encrypted.encrypted, encrypted.iv, encrypted.authTag, account.id] },
+            );
+            logger.info(`Encrypted TOTP secret for account ${account.id}`);
+        }
+    },
+};

--- a/server/models/Account.js
+++ b/server/models/Account.js
@@ -1,6 +1,17 @@
 const Sequelize = require("sequelize");
 const db = require("../utils/database");
 const speakeasy = require("speakeasy");
+const logger = require("../utils/logger");
+const { encrypt, decrypt } = require("../utils/encryption");
+
+const encryptTotpSecret = (account) => {
+    if (!account.totpSecret) return;
+
+    const encrypted = encrypt(account.totpSecret);
+    account.totpSecret = encrypted.encrypted;
+    account.totpSecretIV = encrypted.iv;
+    account.totpSecretAuthTag = encrypted.authTag;
+};
 
 module.exports = db.define("accounts", {
     firstName: {
@@ -29,6 +40,14 @@ module.exports = db.define("accounts", {
             return speakeasy.generateSecret({ name: "Nexterm" }).base32;
         },
     },
+    totpSecretIV: {
+        type: Sequelize.STRING,
+        allowNull: true,
+    },
+    totpSecretAuthTag: {
+        type: Sequelize.STRING,
+        allowNull: true,
+    },
     sessionSync: {
         type: Sequelize.STRING,
         defaultValue: "same_browser",
@@ -52,21 +71,35 @@ module.exports = db.define("accounts", {
     createdAt: false, 
     updatedAt: false,
     hooks: {
+        beforeCreate: encryptTotpSecret,
+        beforeUpdate: (account) => {
+            if (account.changed("totpSecret")) encryptTotpSecret(account);
+        },
         afterFind: (accounts) => {
-            const parsePreferences = (account) => {
-                if (account && account.preferences && typeof account.preferences === 'string') {
+            const processAccount = (account) => {
+                if (!account) return;
+
+                if (account.preferences && typeof account.preferences === "string") {
                     try {
                         account.preferences = JSON.parse(account.preferences);
                     } catch {
                         account.preferences = {};
                     }
                 }
+
+                if (account.totpSecret && account.totpSecretIV && account.totpSecretAuthTag) {
+                    try {
+                        account.totpSecret = decrypt(account.totpSecret, account.totpSecretIV, account.totpSecretAuthTag);
+                    } catch (err) {
+                        logger.error("Failed to decrypt TOTP secret", { accountId: account.id, error: err.message });
+                    }
+                }
             };
-            
+
             if (Array.isArray(accounts)) {
-                accounts.forEach(parsePreferences);
+                accounts.forEach(processAccount);
             } else if (accounts) {
-                parsePreferences(accounts);
+                processAccount(accounts);
             }
         },
     },


### PR DESCRIPTION
## 📋 Description

TOTP (two-factor) secrets are stored in plaintext in the `accounts` table. Anyone with read access to the database or a backup can read `totpSecret` directly and generate valid 2FA codes, which defeats two-factor authentication.

This change encrypts `totpSecret` at rest with AES-256-GCM (via `utils/encryption`):

- Keep the ciphertext in the existing `totpSecret` column and add per-row `totpSecretIV` and `totpSecretAuthTag` columns.
- Encrypt in `beforeCreate` / `beforeUpdate` and decrypt in `afterFind`, so callers keep using `account.totpSecret` unchanged (login, `/totp/secret`, `/totp/enable`).
- Migration `0042` backfills existing plaintext secrets in place (idempotent), so existing authenticator enrollments keep working with no re-setup.
- `listUsers` excludes the new ciphertext columns.

Verified locally on SQLite:
- An existing plaintext secret is encrypted in place by migration `0042` (ciphertext + IV + authTag; no plaintext left on disk).
- Login with the existing authenticator still succeeds (`afterFind` decrypts back to the original secret).
- Newly created accounts are encrypted at rest from the start (`beforeCreate`).

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

<!-- none -->
