### PR TITLE
fix: use undici Agent for insecure requests in the fetch fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "sequelize": "^6.37.8",
     "speakeasy": "^2.0.0",
     "sqlite3": "^6.0.1",
+    "undici": "^7.28.0",
     "uuid": "^14.0.2",
     "webdav": "^5.10.0",
     "winston": "^3.19.0",

--- a/server/lib/engineFetch.js
+++ b/server/lib/engineFetch.js
@@ -31,8 +31,8 @@ const nativeFetch = async (url, options = {}) => {
     };
 
     if (options.insecure) {
-        const { Agent } = require("node:https");
-        fetchOptions.dispatcher = new Agent({ rejectUnauthorized: false });
+        const { Agent } = require("undici");
+        fetchOptions.dispatcher = new Agent({ connect: { rejectUnauthorized: false } });
     }
 
     if (options.body) {


### PR DESCRIPTION
## 📋 Description

The no-engine fetch fallback in `server/lib/engineFetch.js` set the fetch `dispatcher` for insecure requests to a `node:https` Agent. Node's `fetch` (undici) calls `dispatcher.dispatch()`, which a `node:https` Agent does not implement, so every insecure request rejected with `fetch failed` (`agent.dispatch is not a function`).

This fallback runs whenever no engine is connected. It broke adding or using integration hosts that serve self-signed certificates (for example Proxmox VE): the connection test threw `fetch failed` instead of connecting.

The fix uses undici's `Agent` with `connect.rejectUnauthorized`, which the global `fetch` honors, so insecure requests connect as intended. `undici` is already present in the dependency tree transitively; it is now declared explicitly because it is required directly. The lockfile is unchanged.

**Tested:**

- Against a real self-signed endpoint (`self-signed.badssl.com`): plain `fetch` rejects with `DEPTH_ZERO_SELF_SIGNED_CERT`; with the fix it returns `200`.
- Against a real Proxmox VE host with a self-signed certificate and no engine connected: the integration connects and syncs.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

<!-- none -->
