### PR TITLE
fix(integration): atomic removal with cleanup, and connection check on edit

### DIFF
--- a/server/controllers/integration.js
+++ b/server/controllers/integration.js
@@ -300,6 +300,31 @@ module.exports.editIntegration = async (accountId, integrationId, configuration)
 
     const rootFolder = await Folder.findOne({ where: { integrationId, type: "integration-root" } });
 
+    const connectionChanged = ["ip", "port", "username", "password"].some((field) => configuration[field] !== undefined);
+    if (connectionChanged) {
+        const provider = getProvider(integration.type);
+        const ip = configuration.ip !== undefined ? configuration.ip : integration.config.ip;
+        const port = configuration.port !== undefined ? configuration.port : integration.config.port;
+
+        if (provider?.testConnection) {
+            const existingCredential = configuration.password === undefined
+                ? await Credential.findOne({ where: { integrationId, type: "password" } })
+                : null;
+
+            try {
+                await provider.testConnection({
+                    ip,
+                    port,
+                    username: configuration.username !== undefined ? configuration.username : integration.config.username,
+                    password: configuration.password !== undefined ? configuration.password : (existingCredential ? existingCredential.secret : null),
+                });
+            } catch (error) {
+                logger.error("Failed to connect to integration host", { ip, port, error: error.message });
+                return mapConnectionError(error, ip, port);
+            }
+        }
+    }
+
     if (configuration.folderId) {
         const folderCheck = await validateFolderAccess(accountId, configuration.folderId);
         if (!folderCheck.valid) return folderCheck.error;

--- a/server/controllers/integration.js
+++ b/server/controllers/integration.js
@@ -3,6 +3,10 @@ const logger = require("../utils/logger");
 const Folder = require("../models/Folder");
 const Credential = require("../models/Credential");
 const Entry = require("../models/Entry");
+const MonitoringData = require("../models/MonitoringData");
+const MonitoringSnapshot = require("../models/MonitoringSnapshot");
+const db = require("../utils/database");
+const { Op } = require("sequelize");
 const { hasOrganizationAccess, hasOrganizationPermission, hasAccountPermission, validateFolderAccess } = require("../utils/permission");
 const { Permission } = require("../permissions/registry");
 const { getProvider, entryKey } = require("../lib/hypervisors");
@@ -268,9 +272,20 @@ module.exports.deleteIntegration = async (accountId, integrationId) => {
 
     if (!accessCheck.valid) return accessCheck.error;
 
-    await Entry.destroy({ where: { integrationId } });
-    await Folder.destroy({ where: { integrationId } });
-    await Integration.destroy({ where: { id: integrationId } });
+    const entries = await Entry.findAll({ where: { integrationId }, attributes: ["id"] });
+    const entryIds = entries.map((entry) => entry.id);
+    const monitoringWhere = entryIds.length
+        ? { [Op.or]: [{ integrationId }, { entryId: entryIds }] }
+        : { integrationId };
+
+    await db.transaction(async (transaction) => {
+        await MonitoringData.destroy({ where: monitoringWhere, transaction });
+        await MonitoringSnapshot.destroy({ where: monitoringWhere, transaction });
+        await Credential.destroy({ where: { integrationId }, transaction });
+        await Entry.destroy({ where: { integrationId }, transaction });
+        await Folder.destroy({ where: { integrationId }, transaction });
+        await Integration.destroy({ where: { id: integrationId }, transaction });
+    });
 
     logger.info(`Integration deleted`, { integrationId, name: integration.name });
 


### PR DESCRIPTION
## 📋 Description

Two fixes to the integration lifecycle, both in `server/controllers/integration.js`.

**Removing an integration is now atomic and complete.** `deleteIntegration` ran three separate destroys (`Entry`, `Folder`, `Integration`) with no transaction, and never removed the integration's credential or monitoring rows (SQLite does not enforce the `ON DELETE CASCADE` at runtime). If a later step failed, for example a transient SQLite lock while the monitoring services were writing, the earlier deletes had already committed and left the integration row alive without its folders and entries. That leftover integration kept showing on the monitoring page and made auto-sync fail on every cycle with "Cannot determine an owner for the integration root folder". The deletion now runs in a transaction and also removes the integration's credential, monitoring data and monitoring snapshot, so removing an integration is all-or-nothing and leaves nothing behind.

**Editing an integration now validates the connection before saving.** `createIntegration` tests the connection before persisting, but `editIntegration` did not, so saving an edit with wrong credentials or an unreachable host persisted the bad config and left the integration polling with credentials that never authenticate. The edit now tests the connection when it changes the host, port, username or password, and returns the same error the create flow does instead of saving.

**Tested** on SQLite:

- Removing a Proxmox integration with monitoring enabled deletes the integration, its credential and all its monitoring rows in one transaction; the monitoring page no longer shows a stale entry and auto-sync stops erroring.
- Editing an integration with a wrong password is rejected with "Invalid credentials for the integration host" and nothing is saved; a name-only edit still saves without a connection test.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

Fixes #1146
