### PR TITLE
feat(sessions): group terminal sessions into named split-screen tabs

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -1613,11 +1613,17 @@
         "splitDown": "Split Down",
         "sendShortcut": "Send Shortcut…",
         "zoom": "Zoom ({{zoom}}%)",
-        "zoomReset": "Reset Zoom"
+        "zoomReset": "Reset Zoom",
+        "group": "Group",
+        "newGroup": "New Group",
+        "removeFromGroup": "Remove from Group",
+        "dissolveGroup": "Dissolve Group"
       },
       "enableSplitView": "Enable Split View",
       "disableSplitView": "Disable Split View",
-      "sessionMenu": "Session Menu"
+      "sessionMenu": "Session Menu",
+      "group": "Group",
+      "dissolveGroup": "Dissolve Group"
     },
     "wol": {
       "successDescription": "Magic packet sent to {{name}}",

--- a/client/src/common/contexts/SessionContext.jsx
+++ b/client/src/common/contexts/SessionContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import { createContext, useContext, useState, useEffect, useCallback, useMemo } from "react";
 import { openPopout, onPopoutClosed } from "@/common/utils/PopoutUtil.js";
 
 export const SessionContext = createContext({});
@@ -28,8 +28,14 @@ export const SessionProvider = ({ children }) => {
         if (activeSessions.some(s => s.id === sessionId)) setActiveSessionId(sessionId);
     }), [activeSessions]);
 
+    const value = useMemo(() => ({
+        activeSessions, setActiveSessions, activeSessionId, setActiveSessionId,
+        poppedOutSessions, popOutSession, sessionGroups, setSessionGroups,
+        activeGroupId, setActiveGroupId,
+    }), [activeSessions, activeSessionId, poppedOutSessions, popOutSession, sessionGroups, activeGroupId]);
+
     return (
-        <SessionContext.Provider value={{ activeSessions, setActiveSessions, activeSessionId, setActiveSessionId, poppedOutSessions, popOutSession, sessionGroups, setSessionGroups, activeGroupId, setActiveGroupId }}>
+        <SessionContext.Provider value={value}>
             {children}
         </SessionContext.Provider>
     );

--- a/client/src/common/contexts/SessionContext.jsx
+++ b/client/src/common/contexts/SessionContext.jsx
@@ -8,6 +8,8 @@ export const SessionProvider = ({ children }) => {
     const [activeSessions, setActiveSessions] = useState([]);
     const [activeSessionId, setActiveSessionId] = useState(null);
     const [poppedOutSessions, setPoppedOutSessions] = useState([]);
+    const [sessionGroups, setSessionGroups] = useState([]);
+    const [activeGroupId, setActiveGroupId] = useState(null);
 
     const popOutSession = useCallback(async (id) => {
         setPoppedOutSessions(p => p.includes(id) ? p : [...p, id]);
@@ -27,7 +29,7 @@ export const SessionProvider = ({ children }) => {
     }), [activeSessions]);
 
     return (
-        <SessionContext.Provider value={{ activeSessions, setActiveSessions, activeSessionId, setActiveSessionId, poppedOutSessions, popOutSession }}>
+        <SessionContext.Provider value={{ activeSessions, setActiveSessions, activeSessionId, setActiveSessionId, poppedOutSessions, popOutSession, sessionGroups, setSessionGroups, activeGroupId, setActiveGroupId }}>
             {children}
         </SessionContext.Provider>
     );

--- a/client/src/pages/Servers/Servers.jsx
+++ b/client/src/pages/Servers/Servers.jsx
@@ -19,7 +19,7 @@ import { ServerContext } from "@/common/contexts/ServerContext.jsx";
 import { StateStreamContext, STATE_TYPES } from "@/common/contexts/StateStreamContext.jsx";
 import { isTauri } from "@/common/utils/TauriUtil.js";
 import { getTabId, getBrowserId, requiresIdentity, canConnectWithoutPrompt } from "@/common/utils/ConnectionUtil.js";
-import { postRequest, deleteRequest } from "@/common/utils/RequestUtil";
+import { postRequest, deleteRequest, patchRequest } from "@/common/utils/RequestUtil";
 
 export const Servers = () => {
 
@@ -39,13 +39,28 @@ export const Servers = () => {
     const [currentFolderId, setCurrentFolderId] = useState(null);
     const [currentOrganizationId, setCurrentOrganizationId] = useState(null);
     const [editServerId, setEditServerId] = useState(null);
-    const { activeSessions, setActiveSessions, activeSessionId, setActiveSessionId, poppedOutSessions } = useActiveSessions();
+    const { activeSessions, setActiveSessions, activeSessionId, setActiveSessionId, poppedOutSessions, sessionGroups, setSessionGroups } = useActiveSessions();
     const { liveSessions } = useLiveSessions();
     const { getServerById, servers } = useContext(ServerContext);
     const { registerHandler } = useContext(StateStreamContext);
-    const sessionLayout = useSessionLayout();
     const location = useLocation();
     const navigate = useNavigate();
+
+    const activeGroupId = activeSessions.find(s => s.id === activeSessionId)?.groupId ?? null;
+
+    const layoutPersistTimersRef = useRef(new Map());
+    const persistGroupLayout = useCallback((groupId, layout) => {
+        if (!groupId) return;
+        const timers = layoutPersistTimersRef.current;
+        clearTimeout(timers.get(groupId));
+        timers.set(groupId, setTimeout(() => {
+            timers.delete(groupId);
+            patchRequest(`/connections/groups/${groupId}`, { layout: layout || null })
+                .catch(error => console.debug("Failed to persist group layout:", error));
+        }, 400));
+    }, []);
+
+    const sessionLayout = useSessionLayout(activeGroupId, persistGroupLayout);
 
     const [hibernatedSessions, setHibernatedSessions] = useState([]);
     const closingSessionsRef = useRef(new Set());
@@ -72,8 +87,11 @@ export const Servers = () => {
         setLeftPaneSlot(document.getElementById("left-pane-slot"));
     }, []);
 
-    const handleConnectionsUpdate = useCallback((sessions) => {
+    const handleConnectionsUpdate = useCallback((payload) => {
         if (!servers) return;
+        const sessions = Array.isArray(payload) ? payload : (payload?.sessions || []);
+        const groups = Array.isArray(payload) ? [] : (payload?.groups || []);
+        setSessionGroups(groups);
         const mappedSessions = sessions.map(session => {
             const server = getServerById(session.entryId);
             if (!server) return null;
@@ -91,6 +109,7 @@ export const Servers = () => {
                 shareId: session.shareId || null,
                 shareWritable: session.shareWritable || false,
                 participants: session.participants || [],
+                groupId: session.groupId || null,
             };
         }).filter(Boolean);
 
@@ -128,11 +147,24 @@ export const Servers = () => {
             if (prev && (newActiveIds.has(prev) || mergedSessions.some(s => s.id === prev))) return prev;
             return mergedSessions.at(-1)?.id || null;
         });
-    }, [servers, getServerById, setActiveSessions, setActiveSessionId]);
+    }, [servers, getServerById, setActiveSessions, setActiveSessionId, setSessionGroups]);
 
     useEffect(() => {
         if (servers) return registerHandler(STATE_TYPES.CONNECTIONS, handleConnectionsUpdate);
     }, [servers, registerHandler, handleConnectionsUpdate]);
+
+    const prevGroupIdsRef = useRef(new Set());
+    useEffect(() => {
+        const currentIds = new Set(sessionGroups.map(g => g.groupId));
+        prevGroupIdsRef.current.forEach(id => {
+            if (!currentIds.has(id)) sessionLayout.removeGroupState(id);
+        });
+        prevGroupIdsRef.current = currentIds;
+        sessionGroups.forEach(group => {
+            const memberIds = activeSessions.filter(s => (s.groupId ?? null) === group.groupId).map(s => s.id);
+            sessionLayout.hydrateGroup(group.groupId, group.layout, memberIds);
+        });
+    }, [sessionGroups, activeSessions, sessionLayout]);
 
     const findOrganizationForServer = (serverIdNum, entries, currentOrg = null) => {
         for (const entry of entries) {
@@ -394,6 +426,71 @@ export const Servers = () => {
         }
     };
 
+    const groupMemberIds = useCallback((groupId, extraId = null, excludeId = null) => {
+        const ids = activeSessions
+            .filter(s => (s.groupId ?? null) === groupId && s.id !== excludeId)
+            .map(s => s.id);
+        if (extraId && !ids.includes(extraId)) ids.push(extraId);
+        return ids;
+    }, [activeSessions]);
+
+    const createGroupFrom = useCallback(async (sessionIds, name = null) => {
+        const uniqueIds = [...new Set(sessionIds)].filter(Boolean);
+        if (uniqueIds.length < 1) return;
+        try {
+            const result = await postRequest("/connections/groups", {
+                name: name || undefined,
+                sessionIds: uniqueIds,
+                tabId: getTabId(),
+                browserId: getBrowserId(),
+            });
+            const groupId = result?.groupId;
+            if (!groupId) return;
+            setSessionGroups(prev => [...prev, { groupId, name: result.name, order: result.order ?? 0, layout: null }]);
+            setActiveSessions(prev => prev.map(s => uniqueIds.includes(s.id) ? { ...s, groupId } : s));
+            sessionLayout.rebuildGroup(groupId, uniqueIds);
+            setActiveSessionId(uniqueIds[0]);
+        } catch (error) {
+            console.error("Failed to create session group", error);
+        }
+    }, [sessionLayout, setActiveSessions, setActiveSessionId, setSessionGroups]);
+
+    const moveSessionToGroup = useCallback(async (sessionId, groupId) => {
+        const previousGroupId = activeSessions.find(s => s.id === sessionId)?.groupId ?? null;
+        if (previousGroupId === groupId) return;
+        try {
+            await patchRequest(`/connections/${sessionId}/group`, { groupId });
+            const targetMembers = groupId ? groupMemberIds(groupId, sessionId) : [];
+            const previousMembers = previousGroupId ? groupMemberIds(previousGroupId, null, sessionId) : [];
+            setActiveSessions(prev => prev.map(s => s.id === sessionId ? { ...s, groupId } : s));
+            if (groupId) sessionLayout.rebuildGroup(groupId, targetMembers);
+            if (previousGroupId) sessionLayout.rebuildGroup(previousGroupId, previousMembers);
+            setActiveSessionId(sessionId);
+        } catch (error) {
+            console.error("Failed to move session to group", error);
+        }
+    }, [activeSessions, groupMemberIds, sessionLayout, setActiveSessions, setActiveSessionId]);
+
+    const renameGroup = useCallback(async (groupId, name) => {
+        setSessionGroups(prev => prev.map(g => g.groupId === groupId ? { ...g, name } : g));
+        try {
+            await patchRequest(`/connections/groups/${groupId}`, { name });
+        } catch (error) {
+            console.error("Failed to rename group", error);
+        }
+    }, [setSessionGroups]);
+
+    const dissolveGroup = useCallback(async (groupId) => {
+        setSessionGroups(prev => prev.filter(g => g.groupId !== groupId));
+        setActiveSessions(prev => prev.map(s => (s.groupId ?? null) === groupId ? { ...s, groupId: null } : s));
+        sessionLayout.removeGroupState(groupId);
+        try {
+            await deleteRequest(`/connections/groups/${groupId}`);
+        } catch (error) {
+            console.error("Failed to dissolve group", error);
+        }
+    }, [sessionLayout, setActiveSessions, setSessionGroups]);
+
     const openTerminalFromFileManager = async (sessionId, path) => {
         try {
             const originalSession = activeSessions.find(s => s.id === sessionId);
@@ -565,6 +662,12 @@ export const Servers = () => {
                                setOpenFileEditors={setOpenFileEditors}
                                openTerminalFromFileManager={openTerminalFromFileManager}
                                sessionLayout={sessionLayout}
+                               activeGroupId={activeGroupId}
+                               sessionGroups={sessionGroups}
+                               createGroupFrom={createGroupFrom}
+                               moveSessionToGroup={moveSessionToGroup}
+                               renameGroup={renameGroup}
+                               dissolveGroup={dissolveGroup}
                                connectFromDrop={connectFromDrop} />}
             {openFileEditors.map((editor, index) => (
                 editor.type === "preview" ? (

--- a/client/src/pages/Servers/components/ViewContainer/ViewContainer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/ViewContainer.jsx
@@ -32,10 +32,26 @@ export const ViewContainer = ({
                                   setOpenFileEditors,
                                   openTerminalFromFileManager,
                                   sessionLayout,
+                                  activeGroupId = null,
+                                  sessionGroups = [],
+                                  createGroupFrom,
+                                  moveSessionToGroup,
+                                  renameGroup,
+                                  dissolveGroup,
                                   connectFromDrop,
                               }) => {
     const { tree } = sessionLayout;
     const layoutMode = tree ? "split" : "single";
+
+    const activeGroupSessions = useMemo(() => {
+        if (activeGroupId == null) {
+            const active = activeSessions.find(s => s.id === activeSessionId);
+            return active ? [active] : [];
+        }
+        return activeSessions.filter(s => (s.groupId ?? null) === activeGroupId);
+    }, [activeSessions, activeGroupId, activeSessionId]);
+
+    const activeGroupSessionIds = useMemo(() => new Set(activeGroupSessions.map(s => s.id)), [activeGroupSessions]);
     const sessionRefs = useRef({});
     const terminalRefs = useRef({});
     const guacamoleRefs = useRef({});
@@ -154,13 +170,15 @@ export const ViewContainer = ({
         const commandWithNewline = command.endsWith("\n") ? command : command + "\n";
 
         if (broadcastMode && layoutMode !== "single") {
-            Object.entries(terminalRefs.current).forEach(([, { ws }]) => {
+            Object.entries(terminalRefs.current).forEach(([sid, { ws }]) => {
+                if (!activeGroupSessionIds.has(sid)) return;
                 if (ws && ws.readyState === WebSocket.OPEN) {
                     ws.send(commandWithNewline);
                 }
             });
 
-            Object.entries(guacamoleRefs.current).forEach(([, { client }]) => {
+            Object.entries(guacamoleRefs.current).forEach(([sid, { client }]) => {
+                if (!activeGroupSessionIds.has(sid)) return;
                 if (client) {
                     for (let i = 0; i < command.length; i++) {
                         const char = command.charCodeAt(i);
@@ -207,7 +225,7 @@ export const ViewContainer = ({
                 }
             }
         }
-    }, [layoutMode, activeSessionId, broadcastMode, activeSessions]);
+    }, [layoutMode, activeSessionId, broadcastMode, activeSessions, activeGroupSessionIds]);
 
     useEffect(() => {
         if (layoutMode === "single") {
@@ -231,10 +249,11 @@ export const ViewContainer = ({
     }, []);
 
     const focusSession = useCallback((sessionId) => {
-        sessionLayout.showSession(sessionId);
+        const targetGroupId = activeSessions.find(s => s.id === sessionId)?.groupId ?? null;
+        if (targetGroupId != null && targetGroupId === activeGroupId) sessionLayout.showSession(sessionId);
         setActiveSessionId(sessionId);
         focusSessionElement(sessionId);
-    }, [sessionLayout, setActiveSessionId, focusSessionElement]);
+    }, [activeSessions, activeGroupId, sessionLayout, setActiveSessionId, focusSessionElement]);
 
     useEffect(() => {
         const element = layoutRef.current;
@@ -291,25 +310,55 @@ export const ViewContainer = ({
     }, [tree, geometry, sessionLayout]);
 
     const toggleSplitMode = () => {
+        if (activeGroupId == null) {
+            const orderedIds = tabOrderRef.current.filter(id => activeSessions.some(session => session.id === id));
+            const remainingIds = activeSessions.map(session => session.id).filter(id => !orderedIds.includes(id));
+            const allIds = [...orderedIds, ...remainingIds];
+            if (allIds.length >= 2) createGroupFrom?.(allIds);
+            return;
+        }
         if (tree) {
             sessionLayout.clearLayout();
             return;
         }
-        const orderedIds = tabOrderRef.current.filter(id => activeSessions.some(session => session.id === id));
-        const remainingIds = activeSessions.map(session => session.id).filter(id => !orderedIds.includes(id));
-        sessionLayout.splitAll([...orderedIds, ...remainingIds]);
+        sessionLayout.splitAll(activeGroupSessions.map(session => session.id));
     };
 
     const splitActiveWith = useCallback((sessionId, edge) => {
         if (!activeSessionId || activeSessionId === sessionId) return;
+        if (activeGroupId == null) {
+            createGroupFrom?.([activeSessionId, sessionId]);
+            return;
+        }
+        const targetGroupId = activeSessions.find(s => s.id === sessionId)?.groupId ?? null;
+        if (targetGroupId !== activeGroupId) {
+            moveSessionToGroup?.(sessionId, activeGroupId);
+            return;
+        }
         sessionLayout.splitWithSession(activeSessionId, edge, sessionId);
         setActiveSessionId(sessionId);
         focusSessionElement(sessionId);
-    }, [activeSessionId, sessionLayout, setActiveSessionId, focusSessionElement]);
+    }, [activeSessionId, activeGroupId, activeSessions, createGroupFrom, moveSessionToGroup, sessionLayout, setActiveSessionId, focusSessionElement]);
 
     const handlePaneDrop = useCallback((pane, itemType, item, edge) => {
         if (itemType === "server") {
             connectFromDrop(item.id, edge === "center" ? null : { targetSessionId: pane.sessionId, edge });
+            return;
+        }
+
+        if (pane.sessionId === item.sessionId) return;
+
+        const droppedGroupId = activeSessions.find(s => s.id === item.sessionId)?.groupId ?? null;
+
+        // Dropping a session onto a standalone view forms a new group.
+        if (activeGroupId == null) {
+            createGroupFrom?.([pane.sessionId, item.sessionId]);
+            return;
+        }
+
+        // Dropping a session from another group moves it into the active group.
+        if (droppedGroupId !== activeGroupId) {
+            moveSessionToGroup?.(item.sessionId, activeGroupId);
             return;
         }
 
@@ -319,22 +368,21 @@ export const ViewContainer = ({
             return;
         }
 
-        if (pane.sessionId === item.sessionId) return;
         sessionLayout.splitWithSession(pane.sessionId, edge, item.sessionId);
         setActiveSessionId(item.sessionId);
         focusSessionElement(item.sessionId);
-    }, [tree, sessionLayout, connectFromDrop, focusSession, setActiveSessionId, focusSessionElement]);
+    }, [tree, activeSessions, activeGroupId, createGroupFrom, moveSessionToGroup, sessionLayout, connectFromDrop, focusSession, setActiveSessionId, focusSessionElement]);
 
     useEffect(() => {
-        const visibleIds = new Set(activeSessions.map(session => session.id));
+        const visibleIds = activeGroupSessionIds;
         const previousIds = previousSessionIdsRef.current;
         const addedIds = new Set([...visibleIds].filter(id => !previousIds.has(id)));
         const removedAny = [...previousIds].some(id => !visibleIds.has(id));
         previousSessionIdsRef.current = visibleIds;
 
         const nextActiveId = sessionLayout.reconcile({ visibleIds, activeSessionId, addedIds, removedAny });
-        if (nextActiveId !== activeSessionId) setActiveSessionId(nextActiveId);
-    }, [activeSessions, activeSessionId, sessionLayout, setActiveSessionId]);
+        if (nextActiveId && nextActiveId !== activeSessionId) setActiveSessionId(nextActiveId);
+    }, [activeGroupSessionIds, activeSessionId, sessionLayout, setActiveSessionId]);
 
     useEffect(() => {
         if (activeSessionId && activeSessions.some(session => session.id === activeSessionId)) {
@@ -384,7 +432,8 @@ export const ViewContainer = ({
                                       markSessionErrored={markSessionErrored}
                                       getSessionError={getSessionError}
                                       registerTerminalRef={registerTerminalRef} broadcastMode={broadcastMode}
-                                      terminalRefs={terminalRefs} updateProgress={updateSessionProgress}
+                                      terminalRefs={terminalRefs} broadcastSessionIds={activeGroupSessionIds}
+                                      updateProgress={updateSessionProgress}
                                       layoutMode={layoutMode} onBroadcastToggle={toggleBroadcastMode}
                                       onFullscreenToggle={toggleFullscreenMode} />;
             case "sftp":
@@ -467,6 +516,9 @@ export const ViewContainer = ({
                     fullscreenEnabled={fullscreenMode}
                     onFullscreenToggle={toggleFullscreenMode}
                     openNotes={openNotes}
+                    activeGroupId={activeGroupId} sessionGroups={sessionGroups}
+                    createGroupFrom={createGroupFrom} moveSessionToGroup={moveSessionToGroup}
+                    renameGroup={renameGroup} dissolveGroup={dissolveGroup}
                     hibernateSession={hibernateSession} duplicateSession={duplicateSession} />
     );
 

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
@@ -27,6 +27,10 @@ const dropInfo = (monitor, node) => {
     return { zone: "reorder", side: ratio < 0.5 ? "left" : "right" };
 };
 
+const onActivateKey = (handler) => (e) => {
+    if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handler(e); }
+};
+
 const DraggableTab = ({
     session,
     server,
@@ -93,9 +97,10 @@ const DraggableTab = ({
 
     return (
         <div ref={(node) => { nodeRef.current = node; drag(drop(node)); }} onClick={() => setActiveSessionId(session.id)}
+            role="button" tabIndex={0} onKeyDown={onActivateKey(() => setActiveSessionId(session.id))}
             onContextMenu={handleContextMenu}
             onAuxClick={handleAuxClick}
-            className={`server-tab ${session.id === activeSessionId ? "server-tab-active" : ""} ${isDragging ? "dragging" : ""} ${isOver && zone === "merge" ? "drop-merge" : ""} ${isOver && zone === "reorder" ? `drop-reorder drop-reorder-${side}` : ""}`}
+            className={`server-tab ${session.id === activeSessionId ? "server-tab-active" : ""} ${isDragging ? "dragging" : ""} ${isOver && zone === "merge" ? "drop-merge" : ""} ${isOver && zone === "reorder" ? "drop-reorder drop-reorder-" + side : ""}`}
             style={{ opacity: isDragging ? 0.5 : 1 }}>
             <div className={`progress-circle ${!showProgress ? "no-progress" : ""}`}>
                 {showProgress && (
@@ -203,6 +208,7 @@ const GroupTab = ({ group, members, active, activeSessionId, onActivate, onRenam
         <>
             <div ref={(node) => { nodeRef.current = node; drop(node); }}
                  onClick={() => { if (!editing) onActivate?.(); }}
+                 role="button" tabIndex={0} onKeyDown={onActivateKey(() => { if (!editing) onActivate?.(); })}
                  onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); onOpenMenu?.(e); }}
                  onMouseEnter={openPopover} onMouseLeave={scheduleClose}
                  className={`server-tab server-group-tab ${active ? "server-tab-active" : ""} ${isOver ? "drop-target drop-merge" : ""}`}>
@@ -235,7 +241,9 @@ const GroupTab = ({ group, members, active, activeSessionId, onActivate, onRenam
                     {members.map(member => (
                         <div key={member.id}
                              className={`group-popover-item ${member.id === activeSessionId ? "active" : ""}`}
+                             role="button" tabIndex={0}
                              onClick={() => { onFocusMember?.(member.id); setPopover(null); }}
+                             onKeyDown={onActivateKey(() => { onFocusMember?.(member.id); setPopover(null); })}
                              onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setPopover(null); onMemberMenu?.(e, member.id); }}>
                             <Icon path={getIconPath(member.server?.icon)} className="group-popover-icon" />
                             <span className="group-popover-name">{member.server?.name || "?"}</span>

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/ServerTabs.jsx
@@ -1,7 +1,8 @@
 import { useRef, useState, useEffect, useContext } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import Icon from "@mdi/react";
-import { mdiClose, mdiViewSplitVertical, mdiChevronLeft, mdiChevronRight, mdiMenu, mdiFullscreen, mdiFullscreenExit, mdiNoteEditOutline } from "@mdi/js";
+import { mdiClose, mdiViewSplitVertical, mdiChevronLeft, mdiChevronRight, mdiMenu, mdiFullscreen, mdiFullscreenExit, mdiNoteEditOutline, mdiViewGridOutline, mdiDotsVertical } from "@mdi/js";
 import { useDrag, useDrop } from "react-dnd";
 import { useContextMenu } from "@/common/components/ContextMenu";
 import { useActiveSessions } from "@/common/contexts/SessionContext.jsx";
@@ -16,6 +17,16 @@ import KeyboardShortcutsMenu from "../KeyboardShortcutsMenu";
 import SnippetsMenu from "../../renderer/components/SnippetsMenu";
 import "./styles.sass";
 
+const dropInfo = (monitor, node) => {
+    if (!node) return { zone: "reorder", side: "left" };
+    const rect = node.getBoundingClientRect();
+    const offset = monitor.getClientOffset();
+    if (!offset) return { zone: "reorder", side: "left" };
+    const ratio = (offset.x - rect.left) / rect.width;
+    if (ratio > 0.34 && ratio < 0.66) return { zone: "merge", side: null };
+    return { zone: "reorder", side: ratio < 0.5 ? "left" : "right" };
+};
+
 const DraggableTab = ({
     session,
     server,
@@ -25,12 +36,14 @@ const DraggableTab = ({
     onOpenMenu,
     index,
     moveTab,
+    onMergeTab,
     progress = 0,
     pageInfo = null,
 }) => {
     const { getParticipants } = useLiveSessions();
     const { user } = useContext(UserContext);
     const { t } = useTranslation();
+    const nodeRef = useRef(null);
 
     const otherParticipants = getParticipants(session.joinSessionId || session.id)
         .filter(participant => participant.accountId !== user?.id);
@@ -43,12 +56,20 @@ const DraggableTab = ({
         collect: (monitor) => ({ isDragging: monitor.isDragging() }),
     });
 
-    const [{ isOver }, drop] = useDrop({
+    const [{ isOver, zone, side }, drop] = useDrop({
         accept: "TAB",
-        drop: (draggedItem) => {
-            if (draggedItem.index !== index) moveTab(draggedItem.index, index);
+        drop: (draggedItem, monitor) => {
+            if (draggedItem.sessionId === session.id) return;
+            if (dropInfo(monitor, nodeRef.current).zone === "merge") {
+                onMergeTab?.(draggedItem.sessionId, session.id);
+            } else if (draggedItem.index !== index) {
+                moveTab(draggedItem.index, index);
+            }
         },
-        collect: (monitor) => ({ isOver: monitor.isOver() }),
+        collect: (monitor) => {
+            const info = monitor.isOver() ? dropInfo(monitor, nodeRef.current) : {};
+            return { isOver: monitor.isOver(), zone: info.zone || null, side: info.side || null };
+        },
     });
 
     const radius = 10;
@@ -71,10 +92,10 @@ const DraggableTab = ({
     };
 
     return (
-        <div ref={(node) => drag(drop(node))} onClick={() => setActiveSessionId(session.id)}
+        <div ref={(node) => { nodeRef.current = node; drag(drop(node)); }} onClick={() => setActiveSessionId(session.id)}
             onContextMenu={handleContextMenu}
             onAuxClick={handleAuxClick}
-            className={`server-tab ${session.id === activeSessionId ? "server-tab-active" : ""} ${isDragging ? "dragging" : ""} ${isOver ? "drop-target" : ""}`}
+            className={`server-tab ${session.id === activeSessionId ? "server-tab-active" : ""} ${isDragging ? "dragging" : ""} ${isOver && zone === "merge" ? "drop-merge" : ""} ${isOver && zone === "reorder" ? `drop-reorder drop-reorder-${side}` : ""}`}
             style={{ opacity: isDragging ? 0.5 : 1 }}>
             <div className={`progress-circle ${!showProgress ? "no-progress" : ""}`}>
                 {showProgress && (
@@ -120,6 +141,117 @@ const DraggableTab = ({
     );
 };
 
+const MAX_GROUP_NAME = 32;
+
+const GroupTab = ({ group, members, active, activeSessionId, onActivate, onRename, onDissolve, onDropToGroup, onOpenMenu, onFocusMember, onRemoveMember, onMemberMenu }) => {
+    const { t } = useTranslation();
+    const nodeRef = useRef(null);
+    const inputRef = useRef(null);
+    const openedAtRef = useRef(0);
+    const closeTimerRef = useRef(null);
+    const [editing, setEditing] = useState(false);
+    const [name, setName] = useState(group?.name || "");
+    const [popover, setPopover] = useState(null);
+
+    useEffect(() => { if (!editing) setName(group?.name || ""); }, [group?.name, editing]);
+    useEffect(() => () => clearTimeout(closeTimerRef.current), []);
+
+    const [{ isOver }, drop] = useDrop({
+        accept: "TAB",
+        drop: (dragged) => {
+            if (members.some(member => member.id === dragged.sessionId)) return;
+            onDropToGroup?.(dragged.sessionId);
+        },
+        collect: (monitor) => ({ isOver: monitor.isOver() }),
+    });
+
+    const startEdit = (e) => {
+        e.stopPropagation();
+        setPopover(null);
+        openedAtRef.current = Date.now();
+        setEditing(true);
+    };
+
+    const commitRename = () => {
+        setEditing(false);
+        const trimmed = name.trim().slice(0, MAX_GROUP_NAME);
+        if (trimmed && trimmed !== group.name) onRename?.(trimmed);
+        else setName(group?.name || "");
+    };
+
+    const handleBlur = () => {
+        // Activating the tab steals focus to the terminal ~100ms later; ignore that
+        // transient blur so the rename input stays open until the user is done.
+        if (Date.now() - openedAtRef.current < 350) {
+            inputRef.current?.focus();
+            return;
+        }
+        commitRename();
+    };
+
+    const openPopover = () => {
+        clearTimeout(closeTimerRef.current);
+        const rect = nodeRef.current?.getBoundingClientRect();
+        if (rect) setPopover({ left: rect.left, top: rect.bottom + 2 });
+    };
+    const scheduleClose = () => {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = setTimeout(() => setPopover(null), 160);
+    };
+
+    return (
+        <>
+            <div ref={(node) => { nodeRef.current = node; drop(node); }}
+                 onClick={() => { if (!editing) onActivate?.(); }}
+                 onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); onOpenMenu?.(e); }}
+                 onMouseEnter={openPopover} onMouseLeave={scheduleClose}
+                 className={`server-tab server-group-tab ${active ? "server-tab-active" : ""} ${isOver ? "drop-target drop-merge" : ""}`}>
+                <div className="progress-circle no-progress">
+                    <Icon path={mdiViewGridOutline} className="progress-icon" />
+                </div>
+                {editing ? (
+                    <input ref={inputRef} className="group-name-input" autoFocus value={name} maxLength={MAX_GROUP_NAME}
+                           onChange={(e) => setName(e.target.value)}
+                           onClick={(e) => e.stopPropagation()}
+                           onBlur={handleBlur}
+                           onKeyDown={(e) => {
+                               if (e.key === "Enter") { e.stopPropagation(); commitRename(); }
+                               if (e.key === "Escape") { e.stopPropagation(); setEditing(false); setName(group?.name || ""); }
+                           }} />
+                ) : (
+                    <h2 onDoubleClick={startEdit}>
+                        {group?.name || t("servers.tabs.group")}
+                        <span className="tab-group-count">{members.length}</span>
+                    </h2>
+                )}
+                <div className="tab-actions">
+                    <Icon path={mdiClose} className="close-btn" title={t("servers.tabs.dissolveGroup")}
+                          onClick={(e) => { e.stopPropagation(); onDissolve?.(); }} />
+                </div>
+            </div>
+            {popover && !editing && createPortal(
+                <div className="group-popover" style={{ left: popover.left, top: popover.top }}
+                     onMouseEnter={openPopover} onMouseLeave={scheduleClose}>
+                    {members.map(member => (
+                        <div key={member.id}
+                             className={`group-popover-item ${member.id === activeSessionId ? "active" : ""}`}
+                             onClick={() => { onFocusMember?.(member.id); setPopover(null); }}
+                             onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setPopover(null); onMemberMenu?.(e, member.id); }}>
+                            <Icon path={getIconPath(member.server?.icon)} className="group-popover-icon" />
+                            <span className="group-popover-name">{member.server?.name || "?"}</span>
+                            <Icon path={mdiDotsVertical} className="group-popover-menu"
+                                  title={t("servers.tabs.sessionMenu")}
+                                  onClick={(e) => { e.stopPropagation(); setPopover(null); onMemberMenu?.(e, member.id); }} />
+                            <Icon path={mdiClose} className="group-popover-remove"
+                                  title={t("servers.tabs.contextMenu.removeFromGroup")}
+                                  onClick={(e) => { e.stopPropagation(); onRemoveMember?.(member.id); }} />
+                        </div>
+                    ))}
+                </div>, document.body)}
+        </>
+    );
+};
+
 export const ServerTabs = ({
     activeSessions,
     setActiveSessionId,
@@ -141,6 +273,12 @@ export const ServerTabs = ({
     fullscreenEnabled,
     onFullscreenToggle,
     reveal = false,
+    activeGroupId = null,
+    sessionGroups = [],
+    createGroupFrom,
+    moveSessionToGroup,
+    renameGroup,
+    dissolveGroup,
 }) => {
 
     const tabsRef = useRef(null);
@@ -312,6 +450,34 @@ export const ServerTabs = ({
 
     const canSplitSession = (session) => activeSessions.length > 1 && session.id !== activeSessionId;
 
+    const handleMergeTab = (draggedId, targetSessionId) => {
+        const target = activeSessions.find(session => session.id === targetSessionId);
+        if (!target || draggedId === targetSessionId) return;
+        const targetGroupId = target.groupId ?? null;
+        if (targetGroupId) moveSessionToGroup?.(draggedId, targetGroupId);
+        else createGroupFrom?.([targetSessionId, draggedId]);
+    };
+
+    const activateGroup = (members) => {
+        if (!members.length) return;
+        const memberActive = members.find(member => member.id === activeSessionId);
+        setActiveSessionId((memberActive || members[0]).id);
+    };
+
+    const tabItems = [];
+    const seenGroups = new Set();
+    orderedSessions.forEach((session, index) => {
+        const groupId = session.groupId ?? null;
+        if (groupId == null) {
+            tabItems.push({ kind: "session", session, index });
+        } else if (!seenGroups.has(groupId)) {
+            seenGroups.add(groupId);
+            const group = sessionGroups.find(g => g.groupId === groupId) || { groupId, name: null };
+            const members = orderedSessions.filter(s => (s.groupId ?? null) === groupId);
+            tabItems.push({ kind: "group", group, members, index });
+        }
+    });
+
     return (
         <>
             {reveal && <div className="server-tabs-reveal-zone" />}
@@ -337,12 +503,27 @@ export const ServerTabs = ({
                         </div>
                     )}
                     <div className="tabs" ref={tabsRef} onScroll={checkScrollPosition} data-tauri-drag-region>
-                        {orderedSessions.map((session, index) => (
-                            <DraggableTab key={session.id} session={session} server={session.server} index={index} moveTab={moveTab}
+                        {tabItems.map((item) => item.kind === "session" ? (
+                            <DraggableTab key={item.session.id} session={item.session} server={item.session.server}
+                                index={item.index} moveTab={moveTab} onMergeTab={handleMergeTab}
                                 activeSessionId={activeSessionId} setActiveSessionId={setActiveSessionId}
                                 closeSession={closeSession} onOpenMenu={openMenu}
-                                progress={sessionProgress[session.id] || 0}
-                                pageInfo={sessionPageInfo[session.id] || null} />
+                                progress={sessionProgress[item.session.id] || 0}
+                                pageInfo={sessionPageInfo[item.session.id] || null} />
+                        ) : (
+                            <GroupTab key={item.group.groupId} group={item.group} members={item.members}
+                                active={activeGroupId === item.group.groupId} activeSessionId={activeSessionId}
+                                onActivate={() => activateGroup(item.members)}
+                                onRename={(name) => renameGroup?.(item.group.groupId, name)}
+                                onDissolve={() => dissolveGroup?.(item.group.groupId)}
+                                onDropToGroup={(draggedId) => moveSessionToGroup?.(draggedId, item.group.groupId)}
+                                onFocusMember={(id) => setActiveSessionId(id)}
+                                onRemoveMember={(id) => moveSessionToGroup?.(id, null)}
+                                onMemberMenu={(e, id) => openMenu(e, id, { x: e.clientX, y: e.clientY })}
+                                onOpenMenu={(e) => {
+                                    const rep = item.members.find(m => m.id === activeSessionId) || item.members[0];
+                                    if (rep) openMenu(e, rep.id, { x: e.clientX, y: e.clientY });
+                                }} />
                         ))}
                     </div>
                     {showRightArrow && (
@@ -366,7 +547,12 @@ export const ServerTabs = ({
                          onOpenShortcuts={() => setShowShortcuts(true)}
                          onSplitSession={onSplitSession} onPopOut={popOutSession}
                          onOpenNotes={openNotes} onDuplicate={duplicateSession}
-                         onHibernate={hibernateSession} onCloseSession={closeSession} />
+                         onHibernate={hibernateSession} onCloseSession={closeSession}
+                         groups={sessionGroups}
+                         onCreateGroup={createGroupFrom}
+                         onMoveToGroup={moveSessionToGroup}
+                         onRemoveFromGroup={(sessionId) => moveSessionToGroup?.(sessionId, null)}
+                         onDissolveGroup={dissolveGroup} />
 
             <SnippetsMenu visible={showSnippets} onClose={() => setShowSnippets(false)}
                           onSelect={handleSnippetSelect} activeSession={activeSession} />

--- a/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/styles.sass
+++ b/client/src/pages/Servers/components/ViewContainer/components/ServerTabs/styles.sass
@@ -203,6 +203,42 @@
         border-left: 3px solid colors.$primary
         background-color: colors.$primary-opacity
 
+      &.drop-merge
+        border: 2px dashed colors.$primary
+        background-color: colors.$primary-opacity
+
+      &.drop-reorder-left
+        box-shadow: inset 3px 0 0 colors.$primary
+
+      &.drop-reorder-right
+        box-shadow: inset -3px 0 0 colors.$primary
+
+      .tab-group-count
+        display: inline-flex
+        align-items: center
+        justify-content: center
+        min-width: 1.1rem
+        height: 1.1rem
+        padding: 0 0.3rem
+        margin-left: 0.4rem
+        border-radius: 0.6rem
+        background-color: colors.$primary-opacity
+        color: colors.$primary
+        font-size: 0.75rem
+        font-weight: 600
+
+      .group-name-input
+        flex: 1
+        min-width: 0
+        font-size: 1.1rem
+        font-family: inherit
+        color: inherit
+        background-color: colors.$primary-opacity
+        border: 1px solid colors.$primary
+        border-radius: 0.25rem
+        padding: 0.1rem 0.3rem
+        outline: none
+
       svg
         width: 1.2rem
         height: 1.2rem
@@ -365,3 +401,71 @@
 .progress-icon.page-favicon
   object-fit: contain
   border-radius: 0.2rem
+
+.group-popover
+  position: fixed
+  z-index: 10000
+  min-width: 200px
+  max-width: 320px
+  padding: 0.25rem
+  display: flex
+  flex-direction: column
+  gap: 0.1rem
+  background-color: colors.$lighter-background
+  border: 1px solid colors.$dark-gray
+  border-radius: 0.75rem
+  box-shadow: colors.$shadow-lg
+
+  .group-popover-item
+    display: flex
+    align-items: center
+    gap: 0.5rem
+    padding: 0.4rem 0.5rem
+    border-radius: 0.5rem
+    cursor: pointer
+    color: colors.$white
+
+    &:hover
+      background-color: colors.$gray
+
+    &.active
+      background-color: colors.$gray
+      outline: 2px solid colors.$primary
+
+    .group-popover-icon
+      width: 1.2rem
+      height: 1.2rem
+      flex-shrink: 0
+
+    .group-popover-name
+      flex: 1
+      min-width: 0
+      white-space: nowrap
+      overflow: hidden
+      text-overflow: ellipsis
+      font-size: 0.95rem
+
+    .group-popover-menu
+      width: 1.1rem
+      height: 1.1rem
+      flex-shrink: 0
+      opacity: 0.6
+      border-radius: 0.25rem
+      padding: 0.1rem
+
+      &:hover
+        opacity: 1
+        background-color: colors.$gray
+
+    .group-popover-remove
+      width: 1.1rem
+      height: 1.1rem
+      flex-shrink: 0
+      opacity: 0.6
+      border-radius: 0.25rem
+      padding: 0.1rem
+
+      &:hover
+        opacity: 1
+        background-color: colors.$error-opacity
+        color: colors.$error

--- a/client/src/pages/Servers/components/ViewContainer/components/SessionMenu/SessionMenu.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/components/SessionMenu/SessionMenu.jsx
@@ -18,6 +18,8 @@ import {
     mdiPencil,
     mdiShareVariant,
     mdiSleep,
+    mdiViewGridOutline,
+    mdiViewGridPlusOutline,
     mdiViewSplitHorizontal,
     mdiViewSplitVertical,
 } from "@mdi/js";
@@ -62,6 +64,11 @@ export const SessionMenu = ({
     onDuplicate,
     onHibernate,
     onCloseSession,
+    groups = [],
+    onCreateGroup,
+    onMoveToGroup,
+    onRemoveFromGroup,
+    onDissolveGroup,
 }) => {
     const { t } = useTranslation();
 
@@ -76,6 +83,9 @@ export const SessionMenu = ({
     const canOpenNotes = !isNotes && !isJoined && !!server?.id && !session?.scriptId;
     const isSharing = !!session?.shareId;
     const showBroadcast = isTerminal && isActive && layoutMode !== "single";
+    const canGroup = !isNotes && !isJoined;
+    const sessionGroupId = session?.groupId ?? null;
+    const otherGroups = groups.filter(group => group.groupId !== sessionGroupId);
 
     const shareLink = (shareId) => `${getBaseUrl() || window.location.origin}/share/${shareId}`;
 
@@ -156,6 +166,26 @@ export const SessionMenu = ({
                     {canHibernate && (
                         <ContextMenuItem icon={mdiSleep} label={t("servers.tabs.contextMenu.hibernateSession")}
                                          onClick={() => onHibernate(session.id)} />
+                    )}
+                    {canGroup && (
+                        <ContextMenuItem icon={mdiViewGridOutline} label={t("servers.tabs.contextMenu.group")}>
+                            <ContextMenuItem icon={mdiViewGridPlusOutline} label={t("servers.tabs.contextMenu.newGroup")}
+                                             onClick={() => onCreateGroup?.([session.id])} />
+                            {otherGroups.map(group => (
+                                <ContextMenuItem key={group.groupId} icon={mdiViewGridOutline}
+                                                 label={group.name || t("servers.tabs.group")}
+                                                 onClick={() => onMoveToGroup?.(session.id, group.groupId)} />
+                            ))}
+                            {sessionGroupId && (
+                                <>
+                                    <ContextMenuSeparator />
+                                    <ContextMenuItem icon={mdiClose} label={t("servers.tabs.contextMenu.removeFromGroup")}
+                                                     onClick={() => onRemoveFromGroup?.(session.id)} />
+                                    <ContextMenuItem icon={mdiCloseCircle} label={t("servers.tabs.contextMenu.dissolveGroup")}
+                                                     onClick={() => onDissolveGroup?.(sessionGroupId)} danger />
+                                </>
+                            )}
+                        </ContextMenuItem>
                     )}
                     <ContextMenuItem icon={mdiClose} label={t("servers.tabs.contextMenu.closeSession")}
                                      onClick={() => onCloseSession(session.id)} danger />

--- a/client/src/pages/Servers/components/ViewContainer/hooks/useSessionLayout.js
+++ b/client/src/pages/Servers/components/ViewContainer/hooks/useSessionLayout.js
@@ -24,21 +24,43 @@ const pickFocusedPane = (tree, previousLeaves, previousFocusedId) => {
     return leaves[index]?.id ?? null;
 };
 
-export const useSessionLayout = () => {
-    const [state, setState] = useState(EMPTY_STATE);
-    const stateRef = useRef(EMPTY_STATE);
+/**
+ * Layout engine for split-screen session groups. Each group (identified by
+ * groupId) owns its own binary pane tree; the hook operates on the tree of the
+ * currently active group (activeGroupId). A null activeGroupId means a
+ * standalone session, which never has a tree (always rendered single).
+ */
+export const useSessionLayout = (activeGroupId = null, onLayoutChange = null) => {
+    const [version, setVersion] = useState(0);
+    const bump = useCallback(() => setVersion(v => v + 1), []);
+    const statesRef = useRef(new Map());
     const visibleIdsRef = useRef(new Set());
     const pendingPlacementsRef = useRef(new Map());
+    const hydratedRef = useRef(new Set());
+    const activeGroupRef = useRef(activeGroupId);
+    activeGroupRef.current = activeGroupId;
+    const onLayoutChangeRef = useRef(onLayoutChange);
+    onLayoutChangeRef.current = onLayoutChange;
+
+    const getState = (groupId) => statesRef.current.get(groupId) || EMPTY_STATE;
+
+    const writeState = (groupId, normalized, { persist = true } = {}) => {
+        if (normalized.tree) statesRef.current.set(groupId, normalized);
+        else statesRef.current.delete(groupId);
+        bump();
+        if (persist) onLayoutChangeRef.current?.(groupId, normalized.tree ? normalized : null);
+    };
 
     const update = useCallback((updater) => {
-        const current = stateRef.current;
+        const key = activeGroupRef.current;
+        if (key == null) return EMPTY_STATE;
+        const current = getState(key);
         const next = updater(current);
         const tree = normalizeTree(next.tree);
         const unchanged = tree === current.tree && next.focusedPaneId === current.focusedPaneId;
         if (unchanged) return current;
         const normalized = tree ? { tree, focusedPaneId: next.focusedPaneId } : EMPTY_STATE;
-        stateRef.current = normalized;
-        setState(normalized);
+        writeState(key, normalized);
         return normalized;
     }, []);
 
@@ -131,9 +153,55 @@ export const useSessionLayout = () => {
         return findNodeById(result.tree, result.focusedPaneId)?.sessionId ?? activeSessionId;
     }, [update, splitWithSession]);
 
+    // Rebuild a specific group's grid from its member sessions (used when group
+    // membership changes). Resets manual sash sizes for that group.
+    const rebuildGroup = useCallback((groupId, sessionIds) => {
+        if (groupId == null) return;
+        hydratedRef.current.add(groupId);
+        const ids = sessionIds.filter(Boolean);
+        if (ids.length === 0) {
+            writeState(groupId, EMPTY_STATE);
+            return;
+        }
+        const gridTree = buildGridTree(ids);
+        const tree = normalizeTree(gridTree);
+        writeState(groupId, tree ? { tree, focusedPaneId: collectLeaves(gridTree)[0]?.id ?? null } : EMPTY_STATE);
+    }, []);
+
+    // Seed a group's layout once: from server-persisted state if present,
+    // otherwise from an auto-grid of its current members.
+    const hydrateGroup = useCallback((groupId, layout, memberIds = []) => {
+        if (groupId == null || hydratedRef.current.has(groupId)) return;
+        hydratedRef.current.add(groupId);
+        if (layout?.tree) {
+            statesRef.current.set(groupId, {
+                tree: layout.tree,
+                focusedPaneId: layout.focusedPaneId ?? collectLeaves(layout.tree)[0]?.id ?? null,
+            });
+            bump();
+            return;
+        }
+        const ids = memberIds.filter(Boolean);
+        if (ids.length >= 2) {
+            const gridTree = buildGridTree(ids);
+            const tree = normalizeTree(gridTree);
+            if (tree) {
+                statesRef.current.set(groupId, { tree, focusedPaneId: collectLeaves(gridTree)[0]?.id ?? null });
+                bump();
+            }
+        }
+    }, [bump]);
+
+    const removeGroupState = useCallback((groupId) => {
+        hydratedRef.current.delete(groupId);
+        if (statesRef.current.delete(groupId)) bump();
+    }, [bump]);
+
+    const current = getState(activeGroupId);
+
     return useMemo(() => ({
-        tree: state.tree,
-        focusedPaneId: state.focusedPaneId,
+        tree: current.tree,
+        focusedPaneId: current.focusedPaneId,
         splitWithSession,
         showSessionInPane,
         showSession,
@@ -142,5 +210,8 @@ export const useSessionLayout = () => {
         clearLayout,
         resizeBranch,
         reconcile,
-    }), [state, splitWithSession, showSessionInPane, showSession, placeSession, splitAll, clearLayout, resizeBranch, reconcile]);
+        rebuildGroup,
+        hydrateGroup,
+        removeGroupState,
+    }), [version, activeGroupId, current.tree, current.focusedPaneId, splitWithSession, showSessionInPane, showSession, placeSession, splitAll, clearLayout, resizeBranch, reconcile, rebuildGroup, hydrateGroup, removeGroupState]);
 };

--- a/client/src/pages/Servers/components/ViewContainer/renderer/XtermRenderer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/XtermRenderer.jsx
@@ -609,7 +609,7 @@ const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getS
                 Object.entries(terminalRefs.current).forEach(([sessionId, refs]) => {
                     if (sessionId === session.id) return;
                     if (groupIds && !groupIds.has(sessionId)) return;
-                    if (refs.ws && refs.ws.readyState === WebSocket.OPEN) {
+                    if (refs.ws?.readyState === WebSocket.OPEN) {
                         refs.ws.send(data);
                     }
                 });

--- a/client/src/pages/Servers/components/ViewContainer/renderer/XtermRenderer.jsx
+++ b/client/src/pages/Servers/components/ViewContainer/renderer/XtermRenderer.jsx
@@ -32,11 +32,12 @@ const MAX_ZOOM_FONT_SIZE = 40;
 
 const clampFontSize = (size) => Math.min(MAX_ZOOM_FONT_SIZE, Math.max(MIN_ZOOM_FONT_SIZE, size));
 
-const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getSessionError, registerTerminalRef, broadcastMode, terminalRefs, updateProgress, layoutMode, onBroadcastToggle, onFullscreenToggle, isShared = false, onOpenSftp }) => {
+const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getSessionError, registerTerminalRef, broadcastMode, terminalRefs, broadcastSessionIds, updateProgress, layoutMode, onBroadcastToggle, onFullscreenToggle, isShared = false, onOpenSftp }) => {
     const ref = useRef(null);
     const termRef = useRef(null);
     const wsRef = useRef(null);
     const broadcastModeRef = useRef(broadcastMode);
+    const broadcastSessionIdsRef = useRef(broadcastSessionIds);
     const progressParserRef = useRef(null);
     const layoutModeRef = useRef(layoutMode);
     const onBroadcastToggleRef = useRef(onBroadcastToggle);
@@ -144,6 +145,10 @@ const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getS
     useEffect(() => {
         broadcastModeRef.current = broadcastMode;
     }, [broadcastMode]);
+
+    useEffect(() => {
+        broadcastSessionIdsRef.current = broadcastSessionIds;
+    }, [broadcastSessionIds]);
 
     useEffect(() => {
         smartCopyPasteRef.current = smartCopyPaste;
@@ -600,8 +605,11 @@ const XtermRenderer = ({ session, disconnectFromServer, markSessionErrored, getS
             ws.send(data);
 
             if (broadcastModeRef.current && terminalRefs?.current) {
+                const groupIds = broadcastSessionIdsRef.current;
                 Object.entries(terminalRefs.current).forEach(([sessionId, refs]) => {
-                    if (sessionId !== session.id && refs.ws && refs.ws.readyState === WebSocket.OPEN) {
+                    if (sessionId === session.id) return;
+                    if (groupIds && !groupIds.has(sessionId)) return;
+                    if (refs.ws && refs.ws.readyState === WebSocket.OPEN) {
                         refs.ws.send(data);
                     }
                 });

--- a/server/controllers/serverSession.js
+++ b/server/controllers/serverSession.js
@@ -177,8 +177,73 @@ const getSessions = async (accountId, tabId = null, browserId = null) => {
             shareWritable: session.shareWritable || false,
             sftpPath: session.sftpPath || null,
             participants: SessionManager.getParticipants(session.sessionId),
+            groupId: session.groupId || null,
         };
     });
+};
+
+const resolveSyncFilter = async (accountId, tabId, browserId) => {
+    const account = await Account.findByPk(accountId);
+    const sessionSync = account?.sessionSync || 'same_browser';
+    if (sessionSync === 'same_tab') return { filterTabId: tabId, filterBrowserId: undefined };
+    if (sessionSync === 'same_browser') return { filterTabId: undefined, filterBrowserId: browserId };
+    return { filterTabId: undefined, filterBrowserId: undefined };
+};
+
+const getGroups = async (accountId, tabId = null, browserId = null) => {
+    const { filterTabId, filterBrowserId } = await resolveSyncFilter(accountId, tabId, browserId);
+    return SessionManager.getGroups(accountId, filterTabId, filterBrowserId).map(group => ({
+        groupId: group.groupId,
+        name: group.name,
+        order: group.order,
+        layout: group.layout || null,
+    }));
+};
+
+const getConnectionsState = async (accountId, tabId = null, browserId = null) => ({
+    sessions: await getSessions(accountId, tabId, browserId),
+    groups: await getGroups(accountId, tabId, browserId),
+});
+
+const createGroup = (accountId, { name, order, tabId, browserId, sessionIds } = {}) => {
+    const memberIds = Array.isArray(sessionIds) ? sessionIds : [];
+    for (const sessionId of memberIds) {
+        const { error } = validateSessionOwnership(accountId, sessionId);
+        if (error) return error;
+    }
+    const group = SessionManager.createGroup(accountId, { name, order, tabId, browserId });
+    for (const sessionId of memberIds) SessionManager.assignSessionToGroup(sessionId, group.groupId);
+    return { groupId: group.groupId, name: group.name, order: group.order };
+};
+
+const updateGroup = (accountId, groupId, { name, order, layout } = {}) => {
+    const group = SessionManager.getGroup(groupId);
+    if (!group) return { code: 404, message: "Group not found" };
+    if (group.accountId !== accountId) return { code: 403, message: "Access denied" };
+    SessionManager.updateGroup(groupId, { name, order, layout });
+    return { message: "Group updated" };
+};
+
+const deleteGroup = (accountId, groupId) => {
+    const group = SessionManager.getGroup(groupId);
+    if (!group) return { code: 404, message: "Group not found" };
+    if (group.accountId !== accountId) return { code: 403, message: "Access denied" };
+    SessionManager.deleteGroup(groupId);
+    return { message: "Group deleted" };
+};
+
+const moveSessionToGroup = (accountId, sessionId, groupId) => {
+    const { error } = validateSessionOwnership(accountId, sessionId);
+    if (error) return error;
+    if (groupId !== null) {
+        const group = SessionManager.getGroup(groupId);
+        if (!group) return { code: 404, message: "Group not found" };
+        if (group.accountId !== accountId) return { code: 403, message: "Access denied" };
+    }
+    if (!SessionManager.assignSessionToGroup(sessionId, groupId)) {
+        return { code: 404, message: "Session not found" };
+    }
+    return { message: "Session moved" };
 };
 
 const hibernateSession = (sessionId) => {
@@ -358,4 +423,4 @@ const pasteIdentityPassword = async (accountId, sessionId, ipAddress = null, use
     }
 };
 
-module.exports = { createSession, getSessions, getSession, hibernateSession, resumeSession, deleteSession, startSharing, stopSharing, updateSharePermissions, duplicateSession, pasteIdentityPassword };
+module.exports = { createSession, getSessions, getGroups, getConnectionsState, getSession, hibernateSession, resumeSession, deleteSession, startSharing, stopSharing, updateSharePermissions, duplicateSession, pasteIdentityPassword, createGroup, updateGroup, deleteGroup, moveSessionToGroup };

--- a/server/lib/SessionManager.js
+++ b/server/lib/SessionManager.js
@@ -14,11 +14,11 @@ const CONTROL_PLANE_TYPES = new Set(["ssh", "sftp", "guac", "pve-lxc"]);
 const TYPING_DURATION_MS = 1500;
 const PRESENCE_THROTTLE_MS = 250;
 
-module.exports.create = (accountId, entryId, configuration, connectionReason = null, tabId = null, browserId = null, auditLogId = null, organizationId = null, groupId = null) => {
+module.exports.create = (accountId, entryId, configuration, connectionReason = null, tabId = null, browserId = null, auditLogId = null, organizationId = null) => {
     const sessionId = uuidv4();
     const session = {
         sessionId, accountId, entryId, configuration, connectionReason,
-        tabId, browserId, auditLogId, organizationId, groupId,
+        tabId, browserId, auditLogId, organizationId, groupId: null,
         isHibernated: false,
         createdAt: new Date(),
         lastActivity: new Date(),

--- a/server/lib/SessionManager.js
+++ b/server/lib/SessionManager.js
@@ -7,17 +7,18 @@ const stateBroadcaster = require("./StateBroadcaster");
 
 const MAX_LOG_BUFFER_SIZE = 200 * 1024;
 const sessions = new Map();
+const groups = new Map();
 const shareIndex = new Map();
 const CONTROL_PLANE_TYPES = new Set(["ssh", "sftp", "guac", "pve-lxc"]);
 
 const TYPING_DURATION_MS = 1500;
 const PRESENCE_THROTTLE_MS = 250;
 
-module.exports.create = (accountId, entryId, configuration, connectionReason = null, tabId = null, browserId = null, auditLogId = null, organizationId = null) => {
+module.exports.create = (accountId, entryId, configuration, connectionReason = null, tabId = null, browserId = null, auditLogId = null, organizationId = null, groupId = null) => {
     const sessionId = uuidv4();
     const session = {
         sessionId, accountId, entryId, configuration, connectionReason,
-        tabId, browserId, auditLogId, organizationId,
+        tabId, browserId, auditLogId, organizationId, groupId,
         isHibernated: false,
         createdAt: new Date(),
         lastActivity: new Date(),
@@ -50,6 +51,71 @@ module.exports.getAll = (accountId, tabId = undefined, browserId = undefined) =>
         results.push(session);
     }
     return results;
+};
+
+const sessionCountInGroup = (groupId) => {
+    let count = 0;
+    for (const session of sessions.values()) if (session.groupId === groupId) count++;
+    return count;
+};
+
+const pruneGroupIfEmpty = (groupId) => {
+    if (!groupId) return;
+    if (sessionCountInGroup(groupId) === 0 && groups.delete(groupId)) {
+        logger.info("Session group removed (empty)", { groupId });
+    }
+};
+
+module.exports.getGroup = (groupId) => groups.get(groupId) || null;
+
+module.exports.getGroups = (accountId, tabId = undefined, browserId = undefined) => {
+    const results = [];
+    for (const group of groups.values()) {
+        if (group.accountId !== accountId) continue;
+        if (tabId !== undefined && group.tabId !== tabId) continue;
+        if (browserId !== undefined && group.browserId !== browserId) continue;
+        results.push(group);
+    }
+    return results;
+};
+
+module.exports.createGroup = (accountId, { name, order = 0, tabId = null, browserId = null, organizationId = null } = {}) => {
+    const groupId = uuidv4();
+    const group = { groupId, accountId, name: name || "Group", order, tabId, browserId, organizationId, layout: null, createdAt: new Date() };
+    groups.set(groupId, group);
+    logger.info("Session group created", { groupId, accountId });
+    return group;
+};
+
+module.exports.updateGroup = (groupId, { name, order, layout } = {}) => {
+    const group = groups.get(groupId);
+    if (!group) return null;
+    if (name !== undefined) group.name = name;
+    if (order !== undefined) group.order = order;
+    if (layout !== undefined) group.layout = layout;
+    return group;
+};
+
+module.exports.deleteGroup = (groupId) => {
+    const group = groups.get(groupId);
+    if (!group) return false;
+    for (const session of sessions.values()) {
+        if (session.groupId === groupId) session.groupId = null;
+    }
+    groups.delete(groupId);
+    logger.info("Session group deleted", { groupId });
+    return true;
+};
+
+module.exports.assignSessionToGroup = (sessionId, groupId) => {
+    const session = module.exports.get(sessionId);
+    if (!session) return false;
+    if (groupId !== null && !groups.has(groupId)) return false;
+    const previousGroupId = session.groupId;
+    if (previousGroupId === groupId) return true;
+    session.groupId = groupId;
+    if (previousGroupId) pruneGroupIfEmpty(previousGroupId);
+    return true;
 };
 
 const sessionsOfOrganization = function* (organizationId) {
@@ -403,8 +469,9 @@ module.exports.remove = async (sessionId, options = {}) => {
     for (const participant of session.participants.values()) clearTimeout(participant.typingTimer);
     session.participants.clear();
 
-    const { accountId, organizationId } = session;
+    const { accountId, organizationId, groupId } = session;
     sessions.delete(sessionId);
+    pruneGroupIfEmpty(groupId);
     logger.info("Session removed", { sessionId });
     stateBroadcaster.broadcast("CONNECTIONS", { accountId });
     if (organizationId) stateBroadcaster.broadcast("LIVE_SESSIONS", { organizationId });

--- a/server/lib/StateBroadcaster.js
+++ b/server/lib/StateBroadcaster.js
@@ -48,7 +48,7 @@ class StateBroadcaster {
                 const memberships = await OrganizationMember.findAll({ where: { accountId, status: "active" } });
                 return require("../controllers/snippet").listAllAccessibleSnippets(accountId, memberships.map(m => m.organizationId));
             case STATE_TYPES.CONNECTIONS:
-                return require("../controllers/serverSession").getSessions(accountId, tabId, browserId);
+                return require("../controllers/serverSession").getConnectionsState(accountId, tabId, browserId);
             case STATE_TYPES.LIVE_SESSIONS:
                 return require("../controllers/liveSession").listLiveSessions(accountId);
             default:

--- a/server/routes/serverSession.js
+++ b/server/routes/serverSession.js
@@ -1,7 +1,7 @@
 const { Router } = require("express");
-const { createSession, getSessions, getSession, hibernateSession, resumeSession, deleteSession, startSharing, stopSharing, updateSharePermissions, duplicateSession, pasteIdentityPassword } = require("../controllers/serverSession");
+const { createSession, getSessions, getSession, hibernateSession, resumeSession, deleteSession, startSharing, stopSharing, updateSharePermissions, duplicateSession, pasteIdentityPassword, createGroup, updateGroup, deleteGroup, moveSessionToGroup } = require("../controllers/serverSession");
 const { execCommand } = require("../controllers/execCommand");
-const { createSessionValidation, sessionIdValidation, resumeSessionValidation, duplicateSessionValidation } = require("../validations/serverSession");
+const { createSessionValidation, sessionIdValidation, resumeSessionValidation, duplicateSessionValidation, groupIdValidation, createGroupValidation, updateGroupValidation, moveToGroupValidation } = require("../validations/serverSession");
 const { validateSchema } = require("../utils/schema");
 const stateBroadcaster = require("../lib/StateBroadcaster");
 
@@ -277,6 +277,79 @@ app.post("/:entryId/exec", async (req, res) => {
         console.error('Error executing command:', error);
         res.status(500).json({ error: 'Internal server error' });
     }
+});
+
+/**
+ * POST /connections/groups
+ * @summary Create Session Group
+ * @description Creates a named group of terminal sessions shown as a single tab.
+ * @tags Connection
+ * @produces application/json
+ * @security BearerAuth
+ * @return {object} 201 - Group created
+ */
+app.post("/groups", (req, res) => {
+    if (validateSchema(res, createGroupValidation, req.body)) return;
+    const result = createGroup(req.user.id, req.body);
+    if (result?.code) return res.status(result.code).json({ error: result.message });
+    stateBroadcaster.broadcast("CONNECTIONS", { accountId: req.user.id });
+    res.status(201).json(result);
+});
+
+/**
+ * PATCH /connections/groups/{id}
+ * @summary Update Session Group
+ * @description Updates a session group's name, order or split layout.
+ * @tags Connection
+ * @produces application/json
+ * @security BearerAuth
+ * @param {string} id.path.required - Group ID
+ * @return {object} 200 - Success message
+ */
+app.patch("/groups/:id", (req, res) => {
+    if (validateSchema(res, groupIdValidation, req.params)) return;
+    if (validateSchema(res, updateGroupValidation, req.body)) return;
+    const result = updateGroup(req.user.id, req.params.id, req.body);
+    if (result?.code) return res.status(result.code).json({ error: result.message });
+    stateBroadcaster.broadcast("CONNECTIONS", { accountId: req.user.id });
+    res.json(result);
+});
+
+/**
+ * DELETE /connections/groups/{id}
+ * @summary Delete Session Group
+ * @description Dissolves a session group. Member sessions stay open.
+ * @tags Connection
+ * @produces application/json
+ * @security BearerAuth
+ * @param {string} id.path.required - Group ID
+ * @return {object} 200 - Success message
+ */
+app.delete("/groups/:id", (req, res) => {
+    if (validateSchema(res, groupIdValidation, req.params)) return;
+    const result = deleteGroup(req.user.id, req.params.id);
+    if (result?.code) return res.status(result.code).json({ error: result.message });
+    stateBroadcaster.broadcast("CONNECTIONS", { accountId: req.user.id });
+    res.json(result);
+});
+
+/**
+ * PATCH /connections/{id}/group
+ * @summary Move Session To Group
+ * @description Moves a session into a group, or out of any group when groupId is null.
+ * @tags Connection
+ * @produces application/json
+ * @security BearerAuth
+ * @param {string} id.path.required - Session ID
+ * @return {object} 200 - Success message
+ */
+app.patch("/:id/group", (req, res) => {
+    if (validateSchema(res, sessionIdValidation, req.params)) return;
+    if (validateSchema(res, moveToGroupValidation, req.body)) return;
+    const result = moveSessionToGroup(req.user.id, req.params.id, req.body.groupId ?? null);
+    if (result?.code) return res.status(result.code).json({ error: result.message });
+    stateBroadcaster.broadcast("CONNECTIONS", { accountId: req.user.id });
+    res.json(result);
 });
 
 module.exports = app;

--- a/server/validations/serverSession.js
+++ b/server/validations/serverSession.js
@@ -31,3 +31,25 @@ module.exports.duplicateSessionValidation = Joi.object({
     tabId: Joi.string().allow(null).optional(),
     browserId: Joi.string().allow(null).optional()
 });
+
+module.exports.groupIdValidation = Joi.object({
+    id: Joi.string().uuid().required()
+});
+
+module.exports.createGroupValidation = Joi.object({
+    name: Joi.string().max(255).allow(null, '').optional(),
+    order: Joi.number().optional(),
+    tabId: Joi.string().allow(null).optional(),
+    browserId: Joi.string().allow(null).optional(),
+    sessionIds: Joi.array().items(Joi.string().uuid()).optional()
+});
+
+module.exports.updateGroupValidation = Joi.object({
+    name: Joi.string().max(255).optional(),
+    order: Joi.number().optional(),
+    layout: Joi.object().unknown(true).allow(null).optional()
+}).min(1);
+
+module.exports.moveToGroupValidation = Joi.object({
+    groupId: Joi.string().uuid().allow(null).required()
+});


### PR DESCRIPTION
Multiple sessions can be combined into a named group that appears as one tab and renders as a split view. Drag a tab onto another's center to group, onto the edges to reorder; a hover popover lists a group's members to focus, remove, or open the session menu. Each group keeps its own split layout, follows the account's sessionSync scope, and persists across reloads.

## 📋 Description

Terminal sessions can now be organized into named groups. A group is shown as a single tab and rendered as a split view, so several servers can be worked on as one unit instead of juggling many individual tabs.

Everything is driven from the tab bar:
- Drag a tab onto another's **center** to group them; drop on the **edges** to reorder tabs.
- Group tabs show a member count and can be renamed inline (double-click).
- Hover a group tab for a popover to focus a member, remove it from the group, or open its session menu (hibernate, pop out, etc.).

Group membership and split layout are kept server-side alongside the session, scoped by the account's `sessionSync` setting, so groups survive a reload without a schema change.

https://github.com/user-attachments/assets/514900a9-8449-41e3-bdbe-fb220d2630d0

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

Implements the split-screen session grouping requested in #1798.
