### PR TITLE
feat(folders): allow reordering folders via drag and drop

### DIFF
--- a/client/src/pages/Servers/components/ServerList/ServerList.jsx
+++ b/client/src/pages/Servers/components/ServerList/ServerList.jsx
@@ -266,7 +266,7 @@ export const ServerList = ({
                 }
 
                 if (item.type === "folder") {
-                    await patchRequest(`folders/${item.id}`, { parentId: null });
+                    await patchRequest(`folders/${item.id}/reposition`, { parentId: null, organizationId: null });
                     loadServers();
                     return {};
                 }

--- a/client/src/pages/Servers/components/ServerList/components/FolderObject/FolderObject.jsx
+++ b/client/src/pages/Servers/components/ServerList/components/FolderObject/FolderObject.jsx
@@ -43,7 +43,9 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
             if (!offset) return;
             const rect = elementRef.current.getBoundingClientRect();
             const y = offset.y - rect.top;
-            const zone = y < rect.height * 0.3 ? "before" : y > rect.height * 0.7 ? "after" : "nest";
+            let zone = "nest";
+            if (y < rect.height * 0.3) zone = "before";
+            else if (y > rect.height * 0.7) zone = "after";
             setDropZone(prev => prev === zone ? prev : zone);
         },
         drop: async (item) => {
@@ -65,7 +67,7 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
                         organizationId: organizationId
                     });
                 } else {
-                    await patchRequest(`folders/${item.id}`, { parentId: id });
+                    await patchRequest(`folders/${item.id}/reposition`, { parentId: id });
                 }
                 loadServers();
             } catch (error) {
@@ -79,9 +81,8 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
         }),
     });
 
-    const dropZoneClass = isOver
-        ? (dropZone === "before" ? " folder-drop-before" : dropZone === "after" ? " folder-drop-after" : " folder-is-over")
-        : "";
+    const zoneClasses = { before: " folder-drop-before", after: " folder-drop-after" };
+    const dropZoneClass = isOver ? (zoneClasses[dropZone] || " folder-is-over") : "";
 
     const changeName = () => {
         setNameState(name => {

--- a/client/src/pages/Servers/components/ServerList/components/FolderObject/FolderObject.jsx
+++ b/client/src/pages/Servers/components/ServerList/components/FolderObject/FolderObject.jsx
@@ -12,6 +12,8 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
 
     const { loadServers } = useContext(ServerContext);
     const [nameState, setNameState] = useState(name || "");
+    const elementRef = useRef(null);
+    const [dropZone, setDropZone] = useState(null);
 
     useEffect(() => {
         if (!renameState) {
@@ -35,26 +37,40 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
 
     const [{ isOver }, dropRef] = useDrop({
         accept: ["server", "folder"],
+        hover: (item, monitor) => {
+            if (item.type !== "folder" || item.id === id || !acceptsDrop(item) || !elementRef.current) return;
+            const offset = monitor.getClientOffset();
+            if (!offset) return;
+            const rect = elementRef.current.getBoundingClientRect();
+            const y = offset.y - rect.top;
+            const zone = y < rect.height * 0.3 ? "before" : y > rect.height * 0.7 ? "after" : "nest";
+            setDropZone(prev => prev === zone ? prev : zone);
+        },
         drop: async (item) => {
-            if (item.id === id || !acceptsDrop(item)) return { id };
+            if (item.id === id || !acceptsDrop(item)) { setDropZone(null); return { id }; }
+            const zone = dropZone;
+            setDropZone(null);
             try {
                 if (item.type === "server") {
-                    await patchRequest(`entries/${item.id}/reposition`, { 
+                    await patchRequest(`entries/${item.id}/reposition`, {
                         targetId: null,
                         placement: 'after',
                         folderId: id,
                         organizationId: organizationId
                     });
-                    loadServers();
-                    return { id };
+                } else if (zone === "before" || zone === "after") {
+                    await patchRequest(`folders/${item.id}/reposition`, {
+                        targetId: id,
+                        placement: zone,
+                        organizationId: organizationId
+                    });
+                } else {
+                    await patchRequest(`folders/${item.id}`, { parentId: id });
                 }
-
-                await patchRequest(`folders/${item.id}`, { parentId: item.id !== id ? id : undefined });
+                loadServers();
             } catch (error) {
                 console.error("Failed to drop item", error.message);
             }
-
-            loadServers();
 
             return { id };
         },
@@ -62,6 +78,10 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
             isOver: monitor.isOver() && monitor.getItem() != null && acceptsDrop(monitor.getItem()),
         }),
     });
+
+    const dropZoneClass = isOver
+        ? (dropZone === "before" ? " folder-drop-before" : dropZone === "after" ? " folder-drop-after" : " folder-is-over")
+        : "";
 
     const changeName = () => {
         setNameState(name => {
@@ -88,8 +108,10 @@ export const FolderObject = ({ id, name, nestedLevel, position, onClick, isOpen,
         }
     }, [renameState]);
     return (
-        <div className={"folder-object" + (isOver ? " folder-is-over" : "")} data-id={id}
-             ref={(node) => dragRef(dropRef(node))} onClick={renameState ? (e) => e.stopPropagation() : onClick}
+        <div className={"folder-object" + dropZoneClass} data-id={id}
+             role="button" tabIndex={0}
+             onKeyDown={(e) => { if (!renameState && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); onClick?.(e); } }}
+             ref={(node) => { elementRef.current = node; dragRef(dropRef(node)); }} onClick={renameState ? (e) => e.stopPropagation() : onClick}
              style={{ paddingLeft: `${10 + (nestedLevel * 15)}px`, opacity }}>
             {(folderType === 'integration-node' || folderType === 'integration-root') ? (
                 <img src={ProxmoxIcon} alt="Proxmox" style={{ width: '1.5rem', height: '1.5rem' }} />

--- a/client/src/pages/Servers/components/ServerList/components/FolderObject/styles.sass
+++ b/client/src/pages/Servers/components/ServerList/components/FolderObject/styles.sass
@@ -62,3 +62,9 @@
   background-color: colors.$dark-gray
   border: 1px solid colors.$gray
   border-radius: 0.3rem
+
+.folder-drop-before
+  box-shadow: inset 0 2px 0 colors.$primary
+
+.folder-drop-after
+  box-shadow: inset 0 -2px 0 colors.$primary

--- a/client/src/pages/Servers/components/ServerList/components/OrganizationFolder/OrganizationFolder.jsx
+++ b/client/src/pages/Servers/components/ServerList/components/OrganizationFolder/OrganizationFolder.jsx
@@ -35,7 +35,7 @@ const OrganizationFolder = ({ id, name, entries, nestedLevel, connectToServer, c
                 }
 
                 if (item.type === "folder") {
-                    await patchRequest(`folders/${item.id}`, { 
+                    await patchRequest(`folders/${item.id}/reposition`, {
                         parentId: null,
                         organizationId: parseInt(orgId)
                     });

--- a/server/controllers/entry.js
+++ b/server/controllers/entry.js
@@ -14,6 +14,7 @@ const { listIdentities } = require("./identity");
 const { createAuditLog, AUDIT_ACTIONS, RESOURCE_TYPES } = require("./audit");
 const logger = require("../utils/logger");
 const { sendWakeOnLan } = require("../utils/wol");
+const { reorderSiblings } = require("../utils/reposition");
 const stateBroadcaster = require("../lib/StateBroadcaster");
 const SessionManager = require("../lib/SessionManager");
 
@@ -589,32 +590,15 @@ module.exports.repositionEntry = async (accountId, entryId, { targetId, placemen
         order: [["position", "ASC"]],
     });
 
-    const normalizedEntries = entries.filter(e => e.id !== entryIdNum);
-
-    let targetIndex;
-    if (targetId === null || targetId === undefined) {
-        targetIndex = normalizedEntries.length;
-    } else {
-        targetIndex = normalizedEntries.findIndex(e => e.id === parseInt(targetId));
-        if (targetIndex === -1) return { code: 404, message: "Target entry not found" };
-
-        if (placement === 'after') {
-            targetIndex += 1;
-        }
+    if (targetId !== null && targetId !== undefined && !entries.some(e => e.id === Number.parseInt(targetId))) {
+        return { code: 404, message: "Target entry not found" };
     }
 
-    normalizedEntries.splice(targetIndex, 0, entry);
-
-    for (let i = 0; i < normalizedEntries.length; i++) {
-        const updateData = { position: i, folderId: targetFolderId };
-
-        if (normalizedEntries[i].id === entryIdNum) {
-            updateData.organizationId = targetOrganizationId;
-            updateData.accountId = targetAccountId;
-        }
-
-        await Entry.update(updateData, { where: { id: normalizedEntries[i].id } });
-    }
+    await reorderSiblings(Entry, entries, entry, targetId, placement, {
+        organizationId: targetOrganizationId,
+        accountId: targetAccountId,
+        folderId: targetFolderId,
+    });
 
     const oldOrganizationId = entry.organizationId;
     if (oldOrganizationId !== targetOrganizationId) {

--- a/server/controllers/folder.js
+++ b/server/controllers/folder.js
@@ -285,6 +285,111 @@ module.exports.editFolder = async (accountId, folderId, configuration) => {
     return { success: true };
 };
 
+module.exports.repositionFolder = async (accountId, folderId, { targetId, placement, parentId, organizationId }) => {
+    const folderIdNum = parseInt(folderId);
+    const folder = await Folder.findByPk(folderIdNum);
+
+    if (folder === null) {
+        return { code: 301, message: "Folder does not exist" };
+    }
+
+    if (folder.organizationId) {
+        if (!(await hasOrganizationPermission(accountId, folder.organizationId, Permission.RESOURCES_MANAGE)))
+            return { code: 403, message: "You don't have permission to manage resources in this organization" };
+    } else if (folder.accountId !== accountId) {
+        return { code: 403, message: "You don't have permission to edit this folder" };
+    } else if (!(await hasAccountPermission(accountId, Permission.RESOURCES_MANAGE))) {
+        return { code: 403, message: "You don't have permission to manage resources" };
+    }
+
+    let targetParentId, targetOrganizationId, targetAccountId;
+    if (targetId !== null && targetId !== undefined) {
+        const target = await Folder.findByPk(parseInt(targetId));
+        if (!target) return { code: 302, message: "Target folder does not exist" };
+        targetParentId = target.parentId;
+        targetOrganizationId = target.organizationId || null;
+        targetAccountId = target.organizationId ? null : accountId;
+    } else if (parentId !== undefined && parentId !== null) {
+        const parent = await Folder.findByPk(parseInt(parentId));
+        if (!parent) return { code: 302, message: "Target parent folder does not exist" };
+        targetParentId = parent.id;
+        targetOrganizationId = parent.organizationId || null;
+        targetAccountId = parent.organizationId ? null : accountId;
+    } else {
+        targetParentId = null;
+        targetOrganizationId = organizationId !== undefined ? organizationId : (folder.organizationId || null);
+        targetAccountId = targetOrganizationId ? null : accountId;
+    }
+
+    const parentChanged = (folder.parentId || null) !== (targetParentId || null);
+
+    if (parentChanged && folder.type === "integration-node") {
+        return { code: 403, message: "Integration nodes cannot be moved out of their integration folder" };
+    }
+
+    if (targetOrganizationId && targetOrganizationId !== folder.organizationId) {
+        if (!(await hasOrganizationPermission(accountId, targetOrganizationId, Permission.RESOURCES_MANAGE)))
+            return { code: 403, message: "You don't have permission to manage resources in the target organization" };
+    }
+
+    if (parentChanged && targetParentId) {
+        let current = await Folder.findByPk(targetParentId);
+        while (current) {
+            if (current.id === folderIdNum) return { code: 303, message: "Cannot move folder to its own subfolder" };
+            if (current.parentId === null) break;
+            current = await Folder.findByPk(current.parentId);
+        }
+    }
+
+    if (folder.organizationId !== targetOrganizationId) {
+        await updateFolderContext(folderIdNum, targetOrganizationId, targetAccountId, folder.organizationId);
+    }
+
+    const siblings = await Folder.findAll({
+        where: { parentId: targetParentId, organizationId: targetOrganizationId, accountId: targetAccountId },
+        order: [["position", "ASC"]],
+    });
+
+    const normalized = siblings.filter(f => f.id !== folderIdNum);
+
+    let targetIndex;
+    if (targetId === null || targetId === undefined) {
+        targetIndex = normalized.length;
+    } else {
+        targetIndex = normalized.findIndex(f => f.id === parseInt(targetId));
+        if (targetIndex === -1) targetIndex = normalized.length;
+        else if (placement === "after") targetIndex += 1;
+    }
+
+    normalized.splice(targetIndex, 0, folder);
+
+    for (let i = 0; i < normalized.length; i++) {
+        const updateData = { position: i };
+        if (normalized[i].id === folderIdNum) {
+            updateData.parentId = targetParentId;
+            updateData.organizationId = targetOrganizationId;
+            updateData.accountId = targetAccountId;
+        }
+        await Folder.update(updateData, { where: { id: normalized[i].id } });
+    }
+
+    await createAuditLog({
+        action: AUDIT_ACTIONS.FOLDER_MGMT_UPDATE,
+        accountId,
+        organizationId: folder.organizationId,
+        resource: RESOURCE_TYPES.FOLDER,
+        resourceId: folderIdNum,
+        details: { action: "reposition", targetId, placement, parentId: targetParentId },
+    });
+
+    stateBroadcaster.broadcast("ENTRIES", { accountId, organizationId: folder.organizationId });
+    if (targetOrganizationId && targetOrganizationId !== folder.organizationId) {
+        stateBroadcaster.broadcast("ENTRIES", { accountId, organizationId: targetOrganizationId });
+    }
+
+    return { success: true };
+};
+
 module.exports.listFolders = async (accountId) => {
     const personalFolders = await Folder.findAll({
         where: { accountId: accountId },

--- a/server/controllers/folder.js
+++ b/server/controllers/folder.js
@@ -11,6 +11,19 @@ const { createAuditLog, AUDIT_ACTIONS, RESOURCE_TYPES } = require("./audit");
 const stateBroadcaster = require("../lib/StateBroadcaster");
 const logger = require("../utils/logger");
 const SessionManager = require("../lib/SessionManager");
+const { reorderSiblings } = require("../utils/reposition");
+
+const checkFolderManageAccess = async (accountId, folder) => {
+    if (folder.organizationId) {
+        if (!(await hasOrganizationPermission(accountId, folder.organizationId, Permission.RESOURCES_MANAGE)))
+            return { code: 403, message: "You don't have permission to manage resources in this organization" };
+    } else if (folder.accountId !== accountId) {
+        return { code: 403, message: "You don't have permission to edit this folder" };
+    } else if (!(await hasAccountPermission(accountId, Permission.RESOURCES_MANAGE))) {
+        return { code: 403, message: "You don't have permission to manage resources" };
+    }
+    return null;
+};
 
 const cleanupOrganizationIdentities = async (entryIds, oldOrganizationId) => {
     if (!entryIds.length || !oldOrganizationId) return;
@@ -174,14 +187,8 @@ module.exports.editFolder = async (accountId, folderId, configuration) => {
         return { code: 301, message: "Folder does not exist" };
     }
 
-    if (folder.organizationId) {
-        if (!(await hasOrganizationPermission(accountId, folder.organizationId, Permission.RESOURCES_MANAGE)))
-            return { code: 403, message: "You don't have permission to manage resources in this organization" };
-    } else if (folder.accountId !== accountId) {
-        return { code: 403, message: "You don't have permission to edit this folder" };
-    } else if (!(await hasAccountPermission(accountId, Permission.RESOURCES_MANAGE))) {
-        return { code: 403, message: "You don't have permission to manage resources" };
-    }
+    const accessError = await checkFolderManageAccess(accountId, folder);
+    if (accessError) return accessError;
 
     if (configuration.parentId !== undefined && folder.type === "integration-node") {
         return { code: 403, message: "Integration nodes cannot be moved out of their integration folder" };
@@ -285,61 +292,59 @@ module.exports.editFolder = async (accountId, folderId, configuration) => {
     return { success: true };
 };
 
-module.exports.repositionFolder = async (accountId, folderId, { targetId, placement, parentId, organizationId }) => {
-    const folderIdNum = parseInt(folderId);
-    const folder = await Folder.findByPk(folderIdNum);
+const resolveRepositionScope = async (accountId, folder, { targetId, parentId, organizationId }) => {
+    let targetParentId, targetOrganizationId;
 
-    if (folder === null) {
-        return { code: 301, message: "Folder does not exist" };
-    }
-
-    if (folder.organizationId) {
-        if (!(await hasOrganizationPermission(accountId, folder.organizationId, Permission.RESOURCES_MANAGE)))
-            return { code: 403, message: "You don't have permission to manage resources in this organization" };
-    } else if (folder.accountId !== accountId) {
-        return { code: 403, message: "You don't have permission to edit this folder" };
-    } else if (!(await hasAccountPermission(accountId, Permission.RESOURCES_MANAGE))) {
-        return { code: 403, message: "You don't have permission to manage resources" };
-    }
-
-    let targetParentId, targetOrganizationId, targetAccountId;
     if (targetId !== null && targetId !== undefined) {
-        const target = await Folder.findByPk(parseInt(targetId));
-        if (!target) return { code: 302, message: "Target folder does not exist" };
+        const target = await Folder.findByPk(Number.parseInt(targetId));
+        if (!target) return { error: { code: 302, message: "Target folder does not exist" } };
         targetParentId = target.parentId;
         targetOrganizationId = target.organizationId || null;
-        targetAccountId = target.organizationId ? null : accountId;
     } else if (parentId !== undefined && parentId !== null) {
-        const parent = await Folder.findByPk(parseInt(parentId));
-        if (!parent) return { code: 302, message: "Target parent folder does not exist" };
+        const parent = await Folder.findByPk(Number.parseInt(parentId));
+        if (!parent) return { error: { code: 302, message: "Target parent folder does not exist" } };
         targetParentId = parent.id;
         targetOrganizationId = parent.organizationId || null;
-        targetAccountId = parent.organizationId ? null : accountId;
     } else {
         targetParentId = null;
         targetOrganizationId = organizationId !== undefined ? organizationId : (folder.organizationId || null);
-        targetAccountId = targetOrganizationId ? null : accountId;
     }
 
+    const targetAccountId = targetOrganizationId ? null : accountId;
     const parentChanged = (folder.parentId || null) !== (targetParentId || null);
 
     if (parentChanged && folder.type === "integration-node") {
-        return { code: 403, message: "Integration nodes cannot be moved out of their integration folder" };
+        return { error: { code: 403, message: "Integration nodes cannot be moved out of their integration folder" } };
     }
 
-    if (targetOrganizationId && targetOrganizationId !== folder.organizationId) {
-        if (!(await hasOrganizationPermission(accountId, targetOrganizationId, Permission.RESOURCES_MANAGE)))
-            return { code: 403, message: "You don't have permission to manage resources in the target organization" };
+    if (targetOrganizationId && targetOrganizationId !== folder.organizationId
+        && !(await hasOrganizationPermission(accountId, targetOrganizationId, Permission.RESOURCES_MANAGE))) {
+        return { error: { code: 403, message: "You don't have permission to manage resources in the target organization" } };
     }
 
     if (parentChanged && targetParentId) {
         let current = await Folder.findByPk(targetParentId);
         while (current) {
-            if (current.id === folderIdNum) return { code: 303, message: "Cannot move folder to its own subfolder" };
+            if (current.id === folder.id) return { error: { code: 303, message: "Cannot move folder to its own subfolder" } };
             if (current.parentId === null) break;
             current = await Folder.findByPk(current.parentId);
         }
     }
+
+    return { targetParentId, targetOrganizationId, targetAccountId };
+};
+
+module.exports.repositionFolder = async (accountId, folderId, { targetId, placement, parentId, organizationId }) => {
+    const folderIdNum = Number.parseInt(folderId);
+    const folder = await Folder.findByPk(folderIdNum);
+    if (folder === null) return { code: 301, message: "Folder does not exist" };
+
+    const accessError = await checkFolderManageAccess(accountId, folder);
+    if (accessError) return accessError;
+
+    const scope = await resolveRepositionScope(accountId, folder, { targetId, parentId, organizationId });
+    if (scope.error) return scope.error;
+    const { targetParentId, targetOrganizationId, targetAccountId } = scope;
 
     if (folder.organizationId !== targetOrganizationId) {
         await updateFolderContext(folderIdNum, targetOrganizationId, targetAccountId, folder.organizationId);
@@ -349,29 +354,9 @@ module.exports.repositionFolder = async (accountId, folderId, { targetId, placem
         where: { parentId: targetParentId, organizationId: targetOrganizationId, accountId: targetAccountId },
         order: [["position", "ASC"]],
     });
-
-    const normalized = siblings.filter(f => f.id !== folderIdNum);
-
-    let targetIndex;
-    if (targetId === null || targetId === undefined) {
-        targetIndex = normalized.length;
-    } else {
-        targetIndex = normalized.findIndex(f => f.id === parseInt(targetId));
-        if (targetIndex === -1) targetIndex = normalized.length;
-        else if (placement === "after") targetIndex += 1;
-    }
-
-    normalized.splice(targetIndex, 0, folder);
-
-    for (let i = 0; i < normalized.length; i++) {
-        const updateData = { position: i };
-        if (normalized[i].id === folderIdNum) {
-            updateData.parentId = targetParentId;
-            updateData.organizationId = targetOrganizationId;
-            updateData.accountId = targetAccountId;
-        }
-        await Folder.update(updateData, { where: { id: normalized[i].id } });
-    }
+    await reorderSiblings(Folder, siblings, folder, targetId, placement, {
+        parentId: targetParentId, organizationId: targetOrganizationId, accountId: targetAccountId,
+    });
 
     await createAuditLog({
         action: AUDIT_ACTIONS.FOLDER_MGMT_UPDATE,

--- a/server/controllers/folder.js
+++ b/server/controllers/folder.js
@@ -292,24 +292,38 @@ module.exports.editFolder = async (accountId, folderId, configuration) => {
     return { success: true };
 };
 
-const resolveRepositionScope = async (accountId, folder, { targetId, parentId, organizationId }) => {
-    let targetParentId, targetOrganizationId;
+const isDescendantFolder = async (ancestorId, folderId) => {
+    let current = await Folder.findByPk(ancestorId);
+    while (current) {
+        if (current.id === folderId) return true;
+        if (current.parentId === null) return false;
+        current = await Folder.findByPk(current.parentId);
+    }
+    return false;
+};
 
+const resolveTargetLocation = async (folder, { targetId, parentId, organizationId }) => {
     if (targetId !== null && targetId !== undefined) {
         const target = await Folder.findByPk(Number.parseInt(targetId));
         if (!target) return { error: { code: 302, message: "Target folder does not exist" } };
-        targetParentId = target.parentId;
-        targetOrganizationId = target.organizationId || null;
-    } else if (parentId !== undefined && parentId !== null) {
+        return { targetParentId: target.parentId, targetOrganizationId: target.organizationId || null };
+    }
+    if (parentId !== undefined && parentId !== null) {
         const parent = await Folder.findByPk(Number.parseInt(parentId));
         if (!parent) return { error: { code: 302, message: "Target parent folder does not exist" } };
-        targetParentId = parent.id;
-        targetOrganizationId = parent.organizationId || null;
-    } else {
-        targetParentId = null;
-        targetOrganizationId = organizationId !== undefined ? organizationId : (folder.organizationId || null);
+        return { targetParentId: parent.id, targetOrganizationId: parent.organizationId || null };
     }
+    return {
+        targetParentId: null,
+        targetOrganizationId: organizationId !== undefined ? organizationId : (folder.organizationId || null),
+    };
+};
 
+const resolveRepositionScope = async (accountId, folder, params) => {
+    const location = await resolveTargetLocation(folder, params);
+    if (location.error) return location;
+
+    const { targetParentId, targetOrganizationId } = location;
     const targetAccountId = targetOrganizationId ? null : accountId;
     const parentChanged = (folder.parentId || null) !== (targetParentId || null);
 
@@ -322,13 +336,8 @@ const resolveRepositionScope = async (accountId, folder, { targetId, parentId, o
         return { error: { code: 403, message: "You don't have permission to manage resources in the target organization" } };
     }
 
-    if (parentChanged && targetParentId) {
-        let current = await Folder.findByPk(targetParentId);
-        while (current) {
-            if (current.id === folder.id) return { error: { code: 303, message: "Cannot move folder to its own subfolder" } };
-            if (current.parentId === null) break;
-            current = await Folder.findByPk(current.parentId);
-        }
+    if (parentChanged && targetParentId && await isDescendantFolder(targetParentId, folder.id)) {
+        return { error: { code: 303, message: "Cannot move folder to its own subfolder" } };
     }
 
     return { targetParentId, targetOrganizationId, targetAccountId };

--- a/server/routes/folder.js
+++ b/server/routes/folder.js
@@ -1,6 +1,6 @@
 const { Router } = require("express");
-const { folderCreationValidation, folderEditValidation } = require("../validations/folder");
-const { createFolder, deleteFolder, listFolders, editFolder } = require("../controllers/folder");
+const { folderCreationValidation, folderEditValidation, folderRepositionValidation } = require("../validations/folder");
+const { createFolder, deleteFolder, listFolders, editFolder, repositionFolder } = require("../controllers/folder");
 const { validateSchema } = require("../utils/schema");
 
 const app = Router();
@@ -36,6 +36,25 @@ app.put("/", async (req, res) => {
     if (folder?.code) return res.json(folder);
 
     res.json({ message: "Folder has been successfully created", id: folder.id });
+});
+
+/**
+ * PATCH /folder/{folderId}/reposition
+ * @summary Reposition Folder
+ * @description Reorders a folder relative to a sibling folder, or moves it to another parent/root, recomputing sibling positions server-side.
+ * @tags Folder
+ * @produces application/json
+ * @security BearerAuth
+ * @param {string} folderId.path.required - The unique identifier of the folder to reposition
+ * @return {object} 200 - Folder successfully repositioned
+ */
+app.patch("/:folderId/reposition", async (req, res) => {
+    if (validateSchema(res, folderRepositionValidation, req.body)) return;
+
+    const result = await repositionFolder(req.user.id, req.params.folderId, req.body);
+    if (result?.code) return res.json(result);
+
+    res.json({ message: "Folder has been successfully repositioned" });
 });
 
 /**

--- a/server/utils/reposition.js
+++ b/server/utils/reposition.js
@@ -1,0 +1,21 @@
+const reorderSiblings = async (Model, siblings, moved, targetId, placement, movedFields = {}) => {
+    const ordered = siblings.filter(item => item.id !== moved.id);
+
+    let index;
+    if (targetId === null || targetId === undefined) {
+        index = ordered.length;
+    } else {
+        index = ordered.findIndex(item => item.id === Number.parseInt(targetId));
+        if (index === -1) index = ordered.length;
+        else if (placement === "after") index += 1;
+    }
+
+    ordered.splice(index, 0, moved);
+
+    for (let i = 0; i < ordered.length; i++) {
+        const data = ordered[i].id === moved.id ? { position: i, ...movedFields } : { position: i };
+        await Model.update(data, { where: { id: ordered[i].id } });
+    }
+};
+
+module.exports = { reorderSiblings };

--- a/server/validations/folder.js
+++ b/server/validations/folder.js
@@ -11,3 +11,10 @@ module.exports.folderEditValidation = Joi.object({
     parentId: Joi.number().integer().allow(null).optional(),
     organizationId: Joi.number().integer().allow(null).optional()
 }).min(1);
+
+module.exports.folderRepositionValidation = Joi.object({
+    targetId: Joi.number().integer().allow(null).optional(),
+    placement: Joi.string().valid('before', 'after').optional(),
+    parentId: Joi.number().integer().allow(null).optional(),
+    organizationId: Joi.number().integer().allow(null).optional()
+});


### PR DESCRIPTION
Adds a folder reposition endpoint that recomputes sibling positions server-side (mirroring entry reposition), and wires folder-on-folder dragging in the server list: dropping on a folder's top/bottom third reorders it before/after as a sibling, the middle third nests it (previous behavior). Reordering persists via the existing position field.

## 📋 Description

- New `PATCH /folders/:folderId/reposition` endpoint that recomputes sibling positions server-side (mirrors the existing entry reposition).
- In the server list, dropping a folder on another folder's **top/bottom third** reorders it before/after as a sibling; the **middle third** nests it into the target (the previous behavior, unchanged).
- Ordering persists via the existing `position` field; moving a folder to a different parent/root also repositions it in one step.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [ ] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

Closes #1581
