### PR TITLE
fix(mobile): make sftp, ftp, and ftps accessible in the mobile app

### DIFF
--- a/mobile/lib/screens/servers_screen.dart
+++ b/mobile/lib/screens/servers_screen.dart
@@ -590,9 +590,14 @@ class _ServersScreenState extends State<ServersScreen> {
     final directIdentity = await showQuickConnectSheet(context, server);
     if (directIdentity == null || !mounted) return;
 
+    final isFileProtocolForQuickConnect = const {'sftp', 'ftp', 'ftps'}.contains(server.protocol?.toLowerCase());
     _initiateConnection(
       server,
-      type: ServerService.isGuacamoleProtocol(server.protocol) ? ConnectionType.guacamole : ConnectionType.terminal,
+      type: ServerService.isGuacamoleProtocol(server.protocol)
+          ? ConnectionType.guacamole
+          : isFileProtocolForQuickConnect
+              ? ConnectionType.sftp
+              : ConnectionType.terminal,
       directIdentity: directIdentity,
     );
   }
@@ -613,7 +618,13 @@ class _ServersScreenState extends State<ServersScreen> {
       _initiateConnection(server, type: ConnectionType.guacamole);
       return;
     }
-    final isSSH = server.protocol?.toLowerCase() == 'ssh' && !server.isPve;
+    final protocolLower = server.protocol?.toLowerCase();
+    final isFileProtocol = protocolLower == 'sftp' || protocolLower == 'ftp' || protocolLower == 'ftps';
+    if (isFileProtocol) {
+      _initiateConnection(server, type: ConnectionType.sftp);
+      return;
+    }
+    final isSSH = protocolLower == 'ssh' && !server.isPve;
     if (!isSSH) {
       _initiateConnection(server);
       return;


### PR DESCRIPTION
## 📋 Description

**Note:** This is a recreation of #1777 with identical changes. The original PR was mistakenly opened from my fork's `main` branch. This version uses a dedicated fix branch (`fix/mobile-sftp-ftp-access`) instead. No functional changes.

As I described in issue #1586, sftp-only connections (as well as ftp and ftps) cannot be opened in the mobile app. This PR fixes that.

Code changes:
mobile/lib/screens/servers_screen.dart: When the server type is sftp, ftp or ftps, the sftp route previously only available via SSH servers is now invoked.

I tested my code on android. It should also work on ios.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [x] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues

Fixes #1586