### PR TITLE
feat(mobile): add Wake-On-LAN action for servers

### DIFF
--- a/mobile/lib/models/server.dart
+++ b/mobile/lib/models/server.dart
@@ -11,10 +11,13 @@ class Server {
   final String? status;
   final int? integrationId;
   final List<Tag>? tags;
+  final bool? wakeOnLanEnabled;
+  final String? macAddress;
 
   const Server({
     this.id, required this.name, required this.ip, this.icon, this.protocol,
     this.type, this.position, this.identities, this.online, this.status, this.integrationId, this.tags,
+    this.wakeOnLanEnabled, this.macAddress,
   });
 
   factory Server.fromJson(Map<String, dynamic> json) => Server(
@@ -30,16 +33,21 @@ class Server {
     status: json['status'] as String?,
     integrationId: json['integrationId'] as int?,
     tags: (json['tags'] as List<dynamic>?)?.map((t) => Tag.fromJson(t as Map<String, dynamic>)).toList(),
+    wakeOnLanEnabled: json['wakeOnLanEnabled'] as bool?,
+    macAddress: json['macAddress'] as String?,
   );
 
   Map<String, dynamic> toJson() => {
     'id': id, 'name': name, 'ip': ip, 'icon': icon, 'protocol': protocol, 'type': type,
     'position': position, 'identities': identities, 'online': online, 'status': status,
     'integrationId': integrationId, 'tags': tags?.map((t) => t.toJson()).toList(),
+    'wakeOnLanEnabled': wakeOnLanEnabled, 'macAddress': macAddress,
   };
 
   bool get isPve => type?.startsWith('pve-') == true;
   bool get isServer => type == 'server';
+  bool get canWakeOnLan =>
+      wakeOnLanEnabled == true && (macAddress?.trim().isNotEmpty == true);
   bool get isRunning => status != null ? (status == 'running' || status == 'online') : online != false;
   bool get isStopped => status != null ? (status == 'stopped' || status == 'offline') : online == false;
 }

--- a/mobile/lib/screens/servers_screen.dart
+++ b/mobile/lib/screens/servers_screen.dart
@@ -555,6 +555,10 @@ class _ServersScreenState extends State<ServersScreen> {
           _menuItem(ctx, MdiIcons.cursorDefaultClick, 'Quick Connect', cs, () {
             Navigator.pop(ctx); _quickConnect(server);
           }),
+        if (server.canWakeOnLan)
+          _menuItem(ctx, MdiIcons.powerPlug, 'Wake-On-LAN', cs, () {
+            Navigator.pop(ctx); _wakeServer(server);
+          }),
         const SizedBox(height: 12),
       ])),
     );
@@ -595,6 +599,35 @@ class _ServersScreenState extends State<ServersScreen> {
       type: ServerService.isGuacamoleProtocol(server.protocol) ? ConnectionType.guacamole : ConnectionType.terminal,
       directIdentity: directIdentity,
     );
+  }
+
+  Future<void> _wakeServer(Server server) async {
+    final token = widget.authManager.sessionToken;
+    if (token == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Not authenticated'), behavior: SnackBarBehavior.floating));
+      }
+      return;
+    }
+    final entryId = server.id;
+    if (entryId == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Failed to send magic packet: missing server id'), behavior: SnackBarBehavior.floating));
+      }
+      return;
+    }
+    try {
+      await ServerService.wakeServer(token: token, entryId: entryId);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Magic packet sent to ${server.name}'), behavior: SnackBarBehavior.floating));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Failed to send magic packet: $e'), behavior: SnackBarBehavior.floating));
+    }
   }
 
   void _connectToServer(Server server) {

--- a/mobile/lib/services/server_service.dart
+++ b/mobile/lib/services/server_service.dart
@@ -52,6 +52,25 @@ class ServerService {
     return filtered;
   }
 
+  static Future<void> wakeServer({required String token, required dynamic entryId}) async {
+    final response = await ApiClient.post('/entries/$entryId/wake', token: token);
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw Exception('Failed to send Wake-On-LAN packet: ${response.statusCode} - ${response.body}');
+    }
+    if (response.body.isNotEmpty) {
+      try {
+        final data = json.decode(response.body);
+        if (data is Map<String, dynamic>) {
+          final code = data['code'];
+          if (code is int && code >= 300) {
+            throw Exception(data['message'] ?? 'Failed to send Wake-On-LAN packet');
+          }
+        }
+      } on FormatException {
+      }
+    }
+  }
+
   static bool _isSupportedServer(Map<String, dynamic> entry) {
     return entry['type'] == 'server';
   }


### PR DESCRIPTION
## 📋 Description

I didn't want to visit the website every time I needed to use Wake-on-LAN, so I decided to integrate it directly into the mobile app.

**Summary**

This PR adds a new **"Wake-on-LAN"** button to the context menu, which can be accessed by long-pressing a server. The button is only shown if Wake-on-LAN is configured for the selected server.

I also added a simple success/error feedback system to indicate whether the Wake-on-LAN request was successful.

**Screenshot**

<img width="336" height="750" alt="WoL-mobile-implementation" src="https://github.com/user-attachments/assets/99b59e50-779f-42ca-a35c-14d2b09dfa45" />

*Private server names have been blurred using AI.*

**Testing**

I tested and verified all changes on the Android emulator. I expect the implementation to work on iOS as well.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] ⚙️ Engine
- [ ] 🖱️ Connector
- [x] 📱 Mobile
- [ ] ⌨️ CLI
- [ ] 🌐 Landing
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/nexterm), only `en.json` is edited here)

## 🔗 Related Issues